### PR TITLE
Encrypt all tunneled communication

### DIFF
--- a/test/encryption.test.ts
+++ b/test/encryption.test.ts
@@ -1,0 +1,223 @@
+import test from "ava"
+import express, { Request, Response } from "express"
+import type { AddressInfo } from "node:net"
+import { WebSocketServer, WebSocket } from "ws"
+import sodium from "libsodium-wrappers"
+
+import { RA as TunnelServer } from "../tunnel/server.ts"
+import { RA as TunnelClient } from "../tunnel/client.ts"
+
+async function startTunnelApp() {
+  await sodium.ready
+  const app = express()
+
+  app.get("/hello", (_req: Request, res: Response) => {
+    res.status(200).send("world")
+  })
+
+  const tunnelServer = await TunnelServer.initialize(app)
+
+  await new Promise<void>((resolve) => {
+    tunnelServer.server.listen(0, "127.0.0.1", () => resolve())
+  })
+
+  const address = tunnelServer.server.address() as AddressInfo
+  const origin = `http://127.0.0.1:${address.port}`
+
+  const tunnelClient = await TunnelClient.initialize(origin)
+
+  return { tunnelServer, tunnelClient, origin }
+}
+
+async function stopTunnel(
+  tunnelServer: TunnelServer,
+  tunnelClient: TunnelClient
+) {
+  try {
+    const ws: any = (tunnelClient as any).ws
+    if (ws) {
+      ws.onclose = () => {}
+      try {
+        ws.close()
+      } catch {}
+    }
+  } catch {}
+
+  await new Promise<void>((resolve) => {
+    tunnelServer.wss.close(() => resolve())
+  })
+  await new Promise<void>((resolve) => {
+    tunnelServer.server.close(() => resolve())
+  })
+}
+
+test.serial("Wire messages are encrypted after handshake", async (t) => {
+  const { tunnelServer, tunnelClient } = await startTunnelApp()
+
+  // Start a real echo WebSocket server to generate ws events/messages
+  const echoWss = new WebSocketServer({ port: 0, host: "127.0.0.1" })
+  await new Promise<void>((resolve) => echoWss.on("listening", resolve))
+  const echoPort = (echoWss.address() as AddressInfo).port
+  echoWss.on("connection", (ws) => {
+    ws.on("message", (data) => ws.send(data))
+  })
+
+  try {
+    await (tunnelClient as any).ensureConnection()
+    const rawWs: any = (tunnelClient as any).ws
+    const wireMessages: any[] = []
+    const handleWire = (data: any) => {
+      try {
+        const txt = typeof data === "string" ? data : data.toString()
+        const msg = JSON.parse(txt)
+        wireMessages.push(msg)
+      } catch {}
+    }
+    if (typeof rawWs.on === "function") {
+      rawWs.on("message", handleWire)
+    } else if (typeof rawWs.addEventListener === "function") {
+      rawWs.addEventListener("message", (evt: any) => handleWire(evt.data))
+    }
+
+    // Perform a fetch and a ws roundtrip
+    const response = await tunnelClient.fetch("/hello")
+    t.is(response.status, 200)
+    await response.text()
+
+    const TunnelWS = tunnelClient.WebSocket
+    const ws = new TunnelWS(`ws://127.0.0.1:${echoPort}`)
+    await new Promise<void>((resolve) => ws.addEventListener("open", () => resolve()))
+    const echoed = new Promise<string>((resolve) =>
+      ws.addEventListener("message", (evt: any) => resolve(String(evt.data)))
+    )
+    ws.send("ping")
+    t.is(await echoed, "ping")
+    ws.close(1000, "done")
+
+    // Give wire a brief moment to flush
+    await new Promise((r) => setTimeout(r, 100))
+
+    // All observed wire messages (after hooking) must be encrypted envelopes
+    const types = wireMessages.map((m) => m?.type)
+    t.true(types.length > 0)
+    t.true(types.every((tpe) => tpe === "enc"))
+  } finally {
+    await new Promise<void>((resolve) => echoWss.close(() => resolve()))
+    await stopTunnel(tunnelServer, tunnelClient)
+  }
+})
+
+test.serial("Server enforces encryption and responds to encrypted requests", async (t) => {
+  await sodium.ready
+  const app = express()
+  app.get("/hello", (_req: Request, res: Response) => {
+    res.status(200).send("world")
+  })
+
+  const tunnelServer = await TunnelServer.initialize(app)
+  await new Promise<void>((resolve) => {
+    tunnelServer.server.listen(0, "127.0.0.1", () => resolve())
+  })
+  const address = tunnelServer.server.address() as AddressInfo
+  const wsUrl = `ws://127.0.0.1:${address.port}`
+
+  const ws = new WebSocket(wsUrl)
+  try {
+    // Wait for server_kx
+    const serverKx: any = await new Promise((resolve) => {
+      ws.once("message", (data) => resolve(JSON.parse(data.toString())))
+    })
+    t.is(serverKx.type, "server_kx")
+
+    const badPlaintextReq = {
+      type: "http_request",
+      requestId: "r1",
+      method: "GET",
+      url: "/hello",
+      headers: {},
+    }
+
+    // Send plaintext before handshake; server should drop
+    ws.send(JSON.stringify(badPlaintextReq))
+    const noReplyEarly = await Promise.race([
+      new Promise<boolean>((resolve) => ws.once("message", () => resolve(false))),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(true), 150)),
+    ])
+    t.true(noReplyEarly)
+
+    // Complete handshake
+    const serverPub = sodium.from_base64(
+      serverKx.x25519PublicKey,
+      sodium.base64_variants.ORIGINAL
+    )
+    const symmetricKey = sodium.crypto_secretbox_keygen()
+    const sealed = sodium.crypto_box_seal(symmetricKey, serverPub)
+    const clientKx = {
+      type: "client_kx",
+      sealedSymmetricKey: sodium.to_base64(
+        sealed,
+        sodium.base64_variants.ORIGINAL
+      ),
+    }
+    ws.send(JSON.stringify(clientKx))
+
+    // Send plaintext after handshake; server should drop
+    ws.send(JSON.stringify({ ...badPlaintextReq, requestId: "r2" }))
+    const noReplyPost = await Promise.race([
+      new Promise<boolean>((resolve) => ws.once("message", () => resolve(false))),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(true), 150)),
+    ])
+    t.true(noReplyPost)
+
+    // Send encrypted request
+    const httpReq = {
+      type: "http_request",
+      requestId: "r3",
+      method: "GET",
+      url: "/hello",
+      headers: {},
+    }
+    const nonce = sodium.randombytes_buf(sodium.crypto_secretbox_NONCEBYTES)
+    const plaintext = sodium.from_string(JSON.stringify(httpReq))
+    const ciphertext = sodium.crypto_secretbox_easy(plaintext, nonce, symmetricKey)
+    const envelope = {
+      type: "enc",
+      nonce: sodium.to_base64(nonce, sodium.base64_variants.ORIGINAL),
+      ciphertext: sodium.to_base64(
+        ciphertext,
+        sodium.base64_variants.ORIGINAL
+      ),
+    }
+    ws.send(JSON.stringify(envelope))
+
+    // Expect encrypted http_response
+    const encResp: any = await new Promise((resolve) =>
+      ws.once("message", (data) => resolve(JSON.parse(data.toString())))
+    )
+    t.is(encResp.type, "enc")
+    const respNonce = sodium.from_base64(
+      encResp.nonce,
+      sodium.base64_variants.ORIGINAL
+    )
+    const respCipher = sodium.from_base64(
+      encResp.ciphertext,
+      sodium.base64_variants.ORIGINAL
+    )
+    const respPlain = sodium.crypto_secretbox_open_easy(
+      respCipher,
+      respNonce,
+      symmetricKey
+    )
+    const resp = JSON.parse(sodium.to_string(respPlain))
+    t.is(resp.type, "http_response")
+    t.is(resp.requestId, "r3")
+    t.is(resp.status, 200)
+    t.is(resp.statusText, "OK")
+    t.is(resp.body, "world")
+  } finally {
+    await new Promise<void>((resolve) => ws.close() || resolve())
+    await new Promise<void>((resolve) => tunnelServer.wss.close(() => resolve()))
+    await new Promise<void>((resolve) => tunnelServer.server.close(() => resolve()))
+  }
+})
+

--- a/test/missing-key.test.ts
+++ b/test/missing-key.test.ts
@@ -1,0 +1,58 @@
+import test from "ava"
+import express from "express"
+import type { AddressInfo } from "node:net"
+
+import { RA as TunnelServer } from "../tunnel/server.ts"
+import { RA as TunnelClient } from "../tunnel/client.ts"
+
+async function startTunnelApp() {
+  const app = express()
+  app.get("/ok", (_req, res) => res.status(200).send("ok"))
+  const tunnelServer = await TunnelServer.initialize(app)
+  await new Promise<void>((resolve) => {
+    tunnelServer.server.listen(0, "127.0.0.1", () => resolve())
+  })
+  const address = tunnelServer.server.address() as AddressInfo
+  const origin = `http://127.0.0.1:${address.port}`
+  const tunnelClient = await TunnelClient.initialize(origin)
+  return { tunnelServer, tunnelClient }
+}
+
+async function stopTunnel(server: TunnelServer, client: TunnelClient) {
+  try {
+    const ws: any = (client as any).ws
+    if (ws) {
+      ws.onclose = () => {}
+      try {
+        ws.close()
+      } catch {}
+    }
+  } catch {}
+  await new Promise<void>((resolve) => server.wss.close(() => resolve()))
+  await new Promise<void>((resolve) => server.server.close(() => resolve()))
+}
+
+test.serial("Client send fails when symmetric key missing", async (t) => {
+  const { tunnelServer, tunnelClient } = await startTunnelApp()
+  try {
+    // Establish connection so ws is OPEN
+    await (tunnelClient as any).ensureConnection()
+    // Drop the key to simulate corruption/forgetting
+    ;(tunnelClient as any).symmetricKey = undefined
+
+    // fetch should reject because send() requires encryption
+    const fetchErr = await t.throwsAsync(async () => {
+      await tunnelClient.fetch("/ok")
+    })
+    t.truthy(fetchErr)
+
+    // Also verify that low-level send rejects when key is missing
+    await (tunnelClient as any).ensureConnection()
+    ;(tunnelClient as any).symmetricKey = undefined
+    const sendErr = t.throws(() => (tunnelClient as any).send({ type: "noop" }))
+    t.truthy(sendErr)
+  } finally {
+    await stopTunnel(tunnelServer, tunnelClient)
+  }
+})
+

--- a/tunnel/client.ts
+++ b/tunnel/client.ts
@@ -5,6 +5,7 @@ import {
   TunnelWSMessage,
   TunnelServerKX,
   TunnelClientKX,
+  TunnelEncrypted,
 } from "./types.js"
 import { generateRequestId } from "./utils/client.js"
 import { TunnelWebSocket } from "./TunnelWebSocket.js"
@@ -104,12 +105,19 @@ export class RA {
                   : new Error("Failed to process server_kx message")
               )
             }
-          } else if (message.type === "http_response") {
-            this.handleTunnelResponse(message as TunnelHTTPResponse)
-          } else if (message.type === "ws_event") {
-            this.handleWebSocketTunnelEvent(message as TunnelWSServerEvent)
-          } else if (message.type === "ws_message") {
-            this.handleWebSocketTunnelMessage(message as TunnelWSMessage)
+          } else if (message.type === "enc") {
+            // Decrypt and dispatch
+            if (!this.symmetricKey) {
+              throw new Error("Missing symmetric key for encrypted message")
+            }
+            const decrypted = this.decryptEnvelope(message as TunnelEncrypted)
+            if (decrypted.type === "http_response") {
+              this.handleTunnelResponse(decrypted as TunnelHTTPResponse)
+            } else if (decrypted.type === "ws_event") {
+              this.handleWebSocketTunnelEvent(decrypted as TunnelWSServerEvent)
+            } else if (decrypted.type === "ws_message") {
+              this.handleWebSocketTunnelMessage(decrypted as TunnelWSMessage)
+            }
           }
         } catch (error) {
           console.error("Error parsing WebSocket message:", error)
@@ -124,14 +132,66 @@ export class RA {
    * Low-level interfaces to the encrypted WebSocket.
    */
 
-  public send(message: unknown): void {
+  public send(message: any): void {
     if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-      const data =
-        typeof message === "string" ? message : JSON.stringify(message)
-      this.ws.send(data)
+      // Allow plaintext only for client_kx during handshake
+      if (typeof message === "object" && message?.type === "client_kx") {
+        const data = JSON.stringify(message)
+        this.ws.send(data)
+        return
+      }
+
+      if (!this.symmetricKey) {
+        throw new Error("Encryption not ready: missing symmetric key")
+      }
+
+      const envelope = this.encryptPayload(message)
+      this.ws.send(JSON.stringify(envelope))
     } else {
       throw new Error("WebSocket not connected")
     }
+  }
+
+  private encryptPayload(payload: unknown): TunnelEncrypted {
+    if (!this.symmetricKey) {
+      throw new Error("Missing symmetric key")
+    }
+    const nonce = sodium.randombytes_buf(sodium.crypto_secretbox_NONCEBYTES)
+    const plaintext = sodium.from_string(JSON.stringify(payload))
+    const ciphertext = sodium.crypto_secretbox_easy(
+      plaintext,
+      nonce,
+      this.symmetricKey
+    )
+    return {
+      type: "enc",
+      nonce: sodium.to_base64(nonce, sodium.base64_variants.ORIGINAL),
+      ciphertext: sodium.to_base64(
+        ciphertext,
+        sodium.base64_variants.ORIGINAL
+      ),
+    }
+  }
+
+  private decryptEnvelope(envelope: TunnelEncrypted): any {
+    if (!this.symmetricKey) {
+      throw new Error("Missing symmetric key")
+    }
+    const nonce = sodium.from_base64(
+      envelope.nonce,
+      sodium.base64_variants.ORIGINAL
+    )
+    const ciphertext = sodium.from_base64(
+      envelope.ciphertext,
+      sodium.base64_variants.ORIGINAL
+    )
+    const plaintext = sodium.crypto_secretbox_open_easy(
+      ciphertext,
+      nonce,
+      this.symmetricKey
+    )
+    const text = sodium.to_string(plaintext)
+    return JSON.parse(text)
   }
 
   private handleTunnelResponse(response: TunnelHTTPResponse): void {

--- a/tunnel/types.ts
+++ b/tunnel/types.ts
@@ -60,3 +60,12 @@ export type TunnelClientKX = {
   type: "client_kx"
   sealedSymmetricKey: string
 }
+
+// Encrypted envelope carrying any tunneled payload after handshake.
+// The contents (ciphertext) are a JSON-encoded payload of the original
+// tunnel message types, encrypted with XSalsa20-Poly1305 via crypto_secretbox.
+export type TunnelEncrypted = {
+  type: "enc"
+  nonce: string // base64
+  ciphertext: string // base64
+}


### PR DESCRIPTION
Implement end-to-end encryption for all tunneled HTTP and WebSocket traffic.

This secures all tunneled messages (HTTP requests/responses, WebSocket messages/events) using the previously established per-websocket symmetric key, preventing eavesdropping and tampering. The client now encrypts all outbound tunnel messages and decrypts inbound encrypted envelopes, while the server requires and decrypts encrypted messages post-handshake, encrypting all outgoing responses and events.

---
<a href="https://cursor.com/background-agent?bcId=bc-efddefff-684a-4289-aa8e-ef832f23f628">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-efddefff-684a-4289-aa8e-ef832f23f628">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

