### PR TITLE
Add v4 tdx attestation signature verification

### DIFF
--- a/qvl/index.ts
+++ b/qvl/index.ts
@@ -1,3 +1,5 @@
 export * from "./formatters.js"
 export * from "./structs.js"
 export * from "./utils.js"
+
+export * from "./verify.js"

--- a/qvl/structs.ts
+++ b/qvl/structs.ts
@@ -79,12 +79,14 @@ export function parseTdxSignature(sig_data: Buffer) {
     ecdsa_signature: fixed.signature,
     attestation_public_key: fixed.attestation_public_key,
     qe_report_present: fixed.qe_report.length === 384,
+    qe_report: fixed.qe_report,
     qe_report_signature: fixed.qe_report_signature,
     qe_auth_data_len: fixed.qe_auth_data_len,
     qe_auth_data: qe_auth_data,
     cert_data_type: tail.cert_data_type,
     cert_data_len: tail.cert_data_len,
     cert_data_prefix: cert_data.slice(0, 32),
+    cert_data,
   }
 }
 

--- a/qvl/utils.ts
+++ b/qvl/utils.ts
@@ -1,1 +1,56 @@
 export const hex = (b: Buffer) => b.toString("hex")
+
+export function extractPemCertsFromBuffer(certData: Buffer): string[] {
+  const text = certData.toString("utf-8")
+  const regex = /-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g
+  const matches = text.match(regex) || []
+  return matches
+}
+
+export function ecdsaSigRawToDer(sig: Buffer): Buffer {
+  if (sig.length !== 64) throw new Error("Expected 64-byte raw ECDSA signature")
+  const r = sig.slice(0, 32)
+  const s = sig.slice(32, 64)
+
+  const derInt = (bn: Buffer) => {
+    // trim leading zeros
+    let v = Buffer.from(bn)
+    while (v.length > 0 && v[0] === 0x00) v = v.slice(1)
+    // if high bit set, prepend 0x00
+    if (v.length === 0 || (v[0] & 0x80)) v = Buffer.concat([Buffer.from([0x00]), v])
+    return Buffer.concat([Buffer.from([0x02, v.length]), v])
+  }
+
+  const rDer = derInt(r)
+  const sDer = derInt(s)
+  const seqLen = rDer.length + sDer.length
+  return Buffer.concat([Buffer.from([0x30, seqLen]), rDer, sDer])
+}
+
+/** Convert raw P-256 uncompressed public key (x||y, 64 bytes) to SPKI DER */
+export function p256RawPublicKeyToSpkiDer(rawXY: Buffer): Buffer {
+  if (rawXY.length !== 64) throw new Error("Expected 64-byte P-256 public key (x||y)")
+  const uncompressed = Buffer.concat([Buffer.from([0x04]), rawXY])
+
+  // SEQUENCE(
+  //   SEQUENCE(
+  //     OID 1.2.840.10045.2.1 (id-ecPublicKey)
+  //     OID 1.2.840.10045.3.1.7 (secp256r1)
+  //   )
+  //   BIT STRING (0 unused bits) 0x04||X||Y
+  // )
+
+  const idEcPublicKey = Buffer.from([0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01])
+  const secp256r1 = Buffer.from([0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07])
+  const algIdInner = Buffer.concat([idEcPublicKey, secp256r1])
+  const algId = Buffer.concat([Buffer.from([0x30, algIdInner.length]), algIdInner])
+
+  const bitString = Buffer.concat([
+    Buffer.from([0x03, uncompressed.length + 1, 0x00]),
+    uncompressed,
+  ])
+
+  const spkiInner = Buffer.concat([algId, bitString])
+  const spki = Buffer.concat([Buffer.from([0x30, spkiInner.length]), spkiInner])
+  return spki
+}

--- a/qvl/verify.ts
+++ b/qvl/verify.ts
@@ -1,0 +1,80 @@
+import crypto from "crypto"
+
+import { TdxQuoteHeader, TdxQuoteV4, TdxQuoteBody_1_0, parseTdxSignature } from "./structs.js"
+import { ecdsaSigRawToDer, p256RawPublicKeyToSpkiDer } from "./utils.js"
+
+/**
+ * Verify only the quote-level ECDSA signature in a V4 TDX quote.
+ * This does NOT validate the Intel certificate chain or collateral.
+ *
+ * Steps (per DCAP spec and dcap-qvl):
+ * - The signed message is the first 432 bytes (header + report body)
+ * - The signature is a 64-byte raw P-256 (r||s) over SHA256(message)
+ * - The verifying public key is the PCK cert public key embedded in cert_data
+ */
+export function verifyTdxV4QuoteSignature(quote: Buffer): boolean {
+  const header = new TdxQuoteHeader(quote)
+  if (header.version !== 4) throw new Error("Expected TDX quote v4")
+
+  const v4 = new TdxQuoteV4(quote)
+  const sig = parseTdxSignature(v4.sig_data)
+
+  // Compute over header + body (exact struct sizes)
+  const headerSize = (TdxQuoteHeader as any).baseSize as number
+  const bodySize = (TdxQuoteBody_1_0 as any).baseSize as number
+  const signedRegion = quote.subarray(0, headerSize + bodySize)
+
+  // Convert raw 64-byte signature to DER
+  const derSig = ecdsaSigRawToDer(sig.ecdsa_signature)
+
+  // Build SPKI from raw (x||y) public key
+  const spki = p256RawPublicKeyToSpkiDer(sig.attestation_public_key)
+  const keyObj = crypto.createPublicKey({ key: spki, format: "der", type: "spki" })
+
+  // Verify with SHA256
+  const verifier = crypto.createVerify("sha256")
+  verifier.update(signedRegion)
+  verifier.end()
+  const ok = verifier.verify(keyObj, derSig)
+  return ok
+}
+
+/** Convenience base64 wrapper */
+export function verifyTdxV4QuoteSignatureBase64(quoteBase64: string): boolean {
+  return verifyTdxV4QuoteSignature(Buffer.from(quoteBase64, "base64"))
+}
+
+/**
+ * Verify the QE report binds the `attestation_public_key` to the quote.
+ * The QE report is an SGX report whose report_data should contain SHA256(pubkey).
+ * This function checks the binding only; it does not verify the QE report signature chain.
+ */
+export function verifyTdxV4QeReportPublicKeyBinding(quote: Buffer): boolean {
+  const v4 = new TdxQuoteV4(quote)
+  const sig = parseTdxSignature(v4.sig_data)
+
+  if (!sig.qe_report_present) return false
+
+  // SGX report structure: report_data is at offset 320 (64 bytes) in 384-byte report
+  const REPORT_DATA_OFFSET = 320
+  const reportData = sig.qe_report.subarray(REPORT_DATA_OFFSET, REPORT_DATA_OFFSET + 64)
+
+  const candidates: Buffer[] = []
+  const raw = sig.attestation_public_key
+  const with04 = Buffer.concat([Buffer.from([0x04]), raw])
+  const qea = sig.qe_auth_data
+
+  const add = (bufs: Buffer[]) => {
+    const h = crypto.createHash("sha256")
+    for (const b of bufs) h.update(b)
+    candidates.push(h.digest())
+  }
+
+  add([raw])
+  add([with04])
+  add([raw, qea])
+  add([with04, qea])
+
+  return candidates.some((h) => reportData.subarray(0, 32).equals(h))
+}
+

--- a/test/attestation.test.ts
+++ b/test/attestation.test.ts
@@ -1,7 +1,7 @@
 import test from "ava"
 import fs from "node:fs"
 
-import { parseTdxQuoteBase64, hex } from "../qvl"
+import { parseTdxQuoteBase64, hex, verifyTdxV4QuoteSignatureBase64 } from "../qvl"
 
 test.skip("Parse an SGX attestation", async (t) => {
   // TODO
@@ -40,9 +40,16 @@ test.skip("Verify an SGX attestation", async (t) => {
   // TODO
 })
 
-test.skip("Verify a V4 TDX attestation from Google Cloud", async (t) => {
-  // TODO
+test.serial("Verify a V4 TDX attestation signature from Google Cloud", async (t) => {
+  const data = JSON.parse(
+    fs.readFileSync("test/sample/tdx-v4-gcp.json", "utf-8"),
+  )
+  const quote: string = data.tdx.quote
+  const ok = verifyTdxV4QuoteSignatureBase64(quote)
+  t.true(ok)
 })
+
+// QE report binding and full chain/collateral validation are out of scope here.
 
 test.skip("Verify a V5 TDX 1.0 attestation", async (t) => {
   // TODO


### PR DESCRIPTION
Implement V4 TDX quote signature verification to support attestation.

This PR adds the core logic for verifying the ECDSA signature of a V4 TDX quote over its header and report body, using the attestation public key embedded within the quote. This aligns with the approach in `LIT-Protocol/dcap-qvl-ts`. Note that full QE report binding and certificate chain validation are out of scope for this change.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e81c9d7-0eb3-412a-93dd-2c2396e15b69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9e81c9d7-0eb3-412a-93dd-2c2396e15b69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

