### PR TITLE
Fix certificate parsing in binary

### DIFF
--- a/qvl/ATTESTATION-GCP.md
+++ b/qvl/ATTESTATION-GCP.md
@@ -1,0 +1,193 @@
+# TDX Verification
+
+This assumes you have a Google Cloud account.
+
+## Install gcloud SDK
+
+Instructions: https://cloud.google.com/sdk/docs/install-sdk
+
+Check Python version (see instructions):
+
+```
+% python3 -V
+Python 3.13.1
+```
+
+Download and install `gcloud`:
+
+```
+wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-darwin-arm.tar.gz
+tar -vxzf google-cloud-cli-darwin-arm.tar.gz
+./google-cloud-sdk/install.sh  # Select yes when prompted to update $PATH
+source ~/.zshrc                # Or .bashrc, etc.
+```
+
+Sign in interactively with your GCP account, and select or create a project.
+
+(If you get signed out, run `gcloud auth login`. By default, sessions
+will expire after 24 hours.)
+
+```
+gcloud init
+```
+
+Configure the default zone to `us-central1-a`.
+
+If you have to select a new name or change any other configuration
+settings, run the `gcloud init` command again.
+
+---
+
+## Creating a TDX VM
+
+We are going to create a VM with these configuration options:
+
+- Machine type: c3-standard-4
+- Zone: us-central1-a
+- Confidential compute type: TDX
+- Maintenance policy: TERMINATE
+- Image family: ubuntu-2204-lts
+- Image project: ubuntu-os-cloud
+
+```
+gcloud compute instances create gcp-tdx-vm \
+      --machine-type=c3-standard-4 \
+      --zone=us-central1-a \
+      --confidential-compute-type=TDX \
+      --maintenance-policy=TERMINATE \
+      --image-family=ubuntu-2204-lts \
+      --image-project=ubuntu-os-cloud
+```
+
+This should give you output like:
+
+```
+Created [https://www.googleapis.com/compute/v1/projects/tdx-1-468104/zones/us-central1-a/instances/gcp-tdx-vm].
+NAME        ZONE           MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP  EXTERNAL_IP    STATUS
+gcp-tdx-vm  us-central1-a  c3-standard-4               10.128.0.2   35.222.15.208  RUNNING
+```
+
+If you want to remove the VM when you're done (this takes about 30-60 seconds):
+
+```
+gcloud compute instances delete gcp-tdx-vm
+```
+
+## Connecting to the VM
+
+To connect to the VM:
+
+```
+gcloud compute ssh gcp-tdx-vm
+```
+
+This will provision an SSH key, add it to the project metadata, and
+restart the machine allowing SSH.
+
+This does not affect the TDX measurement, since the SSH key is
+provided by a Google metadata service over private networking.
+
+Check that TDX is working:
+
+```
+sudo dmesg | grep -i tdx
+```
+
+This should print `Memory Encryption Features active: Intel TDX`:
+
+```
+$ sudo dmesg | grep -i tdx
+[    0.000000] tdx: Guest detected
+[    1.404759] process: using TDX aware idle routine
+[    1.404759] Memory Encryption Features active: Intel TDX
+```
+
+## Installing the Attestation Client
+
+```
+sudo apt update
+sudo apt install -y golang-go
+```
+
+Check that Go is installed:
+
+```
+go version
+```
+
+```
+go version go1.18.1 linux/amd64
+```
+
+Install the attestation client:
+
+```
+curl -sL https://raw.githubusercontent.com/intel/trustauthority-client-for-go/main/release/install-tdx-cli.sh | sudo bash -
+```
+
+Check that the attestation client is installed:
+
+```
+trustauthority-cli version
+```
+
+```
+Intel® Trust Authority CLI
+Version: v1.10.0-eb394ed
+Build Date: 2025-06-23
+```
+
+Now we must configure the attestation client.
+
+Go to https://portal.trustauthority.intel.com/login and register
+an account. This requires sending an email to Intel Trust Authority
+to get an API key. For full instructions see:
+
+https://docs.trustauthority.intel.com/main/articles/articles/ita/howto-manage-subscriptions.html
+
+Now configure the API key, by creating config.json in your home directory:
+
+```
+touch config.json
+cat <<EOF> config.json
+{
+   "trustauthority_api_url": "https://api.trustauthority.intel.com",
+   "trustauthority_api_key": "<attestation api key>"
+}
+EOF
+```
+
+## Obtaining an Attestation
+
+```
+sudo trustauthority-cli evidence --tdx -c config.json
+```
+
+```
+[DEBUG] GET https://api.trustauthority.intel.com/appraisal/v2/nonce
+{
+  "tdx": {
+     "runtime_data": null,
+     "quote": "BA...",
+     "event_log": "W3...",
+     "verifier_nonce": {
+        "val": "cV...Q==",
+        "iat": "M...EM=",
+        "signature": "vc...L"
+        }
+     }
+}
+```
+
+```
+$ sudo trustauthority-cli token -c config.json
+Trace Id: PkSuTGpKoAMEIPQ=
+Request Id: 2d91b0a5-f26d-4348-83a6-c8a4cead1ca7
+eyJhb...
+```
+
+## Verifying an Attestation
+
+```
+sudo trustauthority-cli evidence --tdx -c config.json > attestation.json
+```

--- a/scripts/debug-azure.ts
+++ b/scripts/debug-azure.ts
@@ -1,0 +1,21 @@
+import fs from "node:fs"
+import { parseTdxQuote } from "../qvl/index.js"
+
+const buf = fs.readFileSync("test/sample/tdx-v4-azure-vtpm.bin")
+const { signature, header } = parseTdxQuote(buf)
+
+function containsPem(b?: Buffer | null): boolean {
+  if (!b) return false
+  const s = b.toString("utf8")
+  return s.includes("-----BEGIN CERTIFICATE-----")
+}
+
+console.log({
+  version: header.version,
+  qe_auth_data_len: signature.qe_auth_data_len,
+  cert_data_type: signature.cert_data_type,
+  cert_data_len: signature.cert_data_len,
+  qe_auth_contains_pem: containsPem(signature.qe_auth_data),
+  cert_data_contains_pem: containsPem(signature.cert_data as Buffer | undefined),
+})
+

--- a/test/attestation.test.ts
+++ b/test/attestation.test.ts
@@ -34,7 +34,6 @@ test.serial("Parse a V4 TDX quote from Tappd, hex format", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.true(verifyTdxV4Signature(quote))
-  t.is(signature.cert_data, null) // Quote is missing cert data
 })
 
 test.serial("Parse a V4 TDX quote from Edgeless, bin format", async (t) => {
@@ -54,7 +53,19 @@ test.serial("Parse a V4 TDX quote from Edgeless, bin format", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.true(verifyTdxV4Signature(quote))
-  t.is(signature.cert_data, null) // Quote is missing cert data
+})
+
+test.serial("Parse a V4 TDX quote from Azure vTPM, bin format, extract certs", async (t) => {
+  const quote = fs.readFileSync("test/sample/tdx-v4-azure-vtpm.bin")
+
+  const { header, body, signature } = parseTdxQuote(quote)
+
+  t.is(header.version, 4)
+  t.is(header.tee_type, 129)
+  t.true(verifyTdxV4Signature(quote))
+  t.truthy(signature.cert_data)
+  const pems = extractPemCertificates(signature.cert_data!)
+  t.is(pems.length, 3)
 })
 
 test.serial("Parse a V4 TDX quote from Phala, bin format", async (t) => {
@@ -74,7 +85,6 @@ test.serial("Parse a V4 TDX quote from Phala, bin format", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.true(verifyTdxV4Signature(quote))
-  t.is(signature.cert_data, null) // Quote is missing cert data
 })
 
 test.serial("Parse a V4 TDX quote from Phala, hex format", async (t) => {
@@ -95,7 +105,6 @@ test.serial("Parse a V4 TDX quote from Phala, hex format", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.true(verifyTdxV4Signature(quote))
-  t.is(signature.cert_data, null) // Quote is missing cert data
 })
 
 test.serial("Parse a V4 TDX quote from MoeMahhouk", async (t) => {
@@ -118,7 +127,6 @@ test.serial("Parse a V4 TDX quote from MoeMahhouk", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.true(verifyTdxV4Signature(quote))
-  t.is(signature.cert_data, null) // Quote is missing cert data
 
   t.deepEqual(
     reverseHexBytes(hex(body.mr_seam)),


### PR DESCRIPTION
Update TDX v4 parser to extract certificates from Azure vTPM quotes by falling back to `qe_auth_data` when `cert_data` tail is absent.

Azure vTPM quotes embed PEM certificates within the `qe_auth_data` field, rather than in the structured `cert_data` tail that the parser previously expected. This PR modifies the parser to correctly identify and expose these certificates.

---
<a href="https://cursor.com/background-agent?bcId=bc-d90c0170-d3f3-44c2-a625-0e7d8ef6210c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d90c0170-d3f3-44c2-a625-0e7d8ef6210c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

