### PR TITLE
Update TDX quote trust chain verification

### DIFF
--- a/qvl/verify.ts
+++ b/qvl/verify.ts
@@ -1,4 +1,4 @@
-import { createPublicKey, createVerify, X509Certificate } from "node:crypto"
+import { createHash, createPublicKey, createVerify, X509Certificate } from "node:crypto"
 
 import { getTdxV4SignedRegion, parseTdxQuote } from "./structs.js"
 import {
@@ -6,6 +6,7 @@ import {
   encodeEcdsaSignatureToDer,
   loadRootCerts,
   toBase64Url,
+  extractPemCertificates,
 } from "./utils.js"
 
 /**
@@ -94,8 +95,8 @@ export function verifyProvisioningCertificationChain(
  * by checking qe_report_signature against the PCK leaf certificate public key.
  */
 export function verifyQeReportSignature(
-  quote: string | Buffer, // TODO: take just what we need to verify
-  certs: string[],
+  quote: string | Buffer,
+  certs?: string[],
 ): boolean {
   const quoteBytes = Buffer.isBuffer(quote)
     ? quote
@@ -104,8 +105,17 @@ export function verifyQeReportSignature(
   const { header, signature } = parseTdxQuote(quoteBytes)
   if (header.version !== 4) throw new Error("Unsupported quote version")
 
-  const { chain } = verifyProvisioningCertificationChain(certs, {
-    verifyAtTimeMs: 0,
+  // If no external certs provided, try to extract from quote's cert_data
+  let providedCerts: string[] = Array.isArray(certs) ? certs : []
+  if (providedCerts.length === 0 && signature.cert_data) {
+    try {
+      providedCerts = extractPemCertificates(signature.cert_data)
+    } catch {}
+  }
+  if (providedCerts.length === 0) return false
+
+  const { chain } = verifyProvisioningCertificationChain(providedCerts, {
+    verifyAtTimeMs: Date.now(),
   })
   if (chain.length === 0) return false
 
@@ -147,56 +157,28 @@ export function verifyQeReportSignature(
   return false
 }
 
-// /**
-//  * Verify QE binding: qe_report.report_data[0..32) == SHA256(attestation_public_key || qe_auth_data)
-//  */
-// export function verifyQeReportBinding(quoteInput: string | Buffer): boolean {
-//   const quoteBytes = Buffer.isBuffer(quoteInput)
-//     ? quoteInput
-//     : Buffer.from(quoteInput, "base64")
+/**
+ * Verify QE binding per DCAP: report_data[0..32) == SHA256(attestation_public_key || qe_auth_data)
+ */
+export function verifyQeReportBinding(quoteInput: string | Buffer): boolean {
+  const quoteBytes = Buffer.isBuffer(quoteInput)
+    ? quoteInput
+    : Buffer.from(quoteInput, "base64")
 
-//   const { header, signature } = parseTdxQuote(quoteBytes)
-//   if (header.version !== 4) throw new Error("Unsupported quote version")
-//   if (!signature.qe_report_present) throw new Error("Missing QE report")
+  const { header, signature } = parseTdxQuote(quoteBytes)
+  if (header.version !== 4) throw new Error("Unsupported quote version")
+  if (!signature.qe_report_present) return false
 
-//   const pubRaw = signature.attestation_public_key
-//   const pubUncompressed = Buffer.concat([Buffer.from([0x04]), pubRaw])
+  const digest = createHash("sha256")
+    .update(signature.attestation_public_key)
+    .update(signature.qe_auth_data)
+    .digest()
 
-//   // Build SPKI DER from JWK and hash that too
-//   const jwk = {
-//     kty: "EC",
-//     crv: "P-256",
-//     x: pubRaw.subarray(0, 32).toString("base64url"),
-//     y: pubRaw.subarray(32, 64).toString("base64url"),
-//   } as const
-//   let spki: Buffer | undefined
-//   try {
-//     spki = createPublicKey({ key: jwk, format: "jwk" }).export({
-//       type: "spki",
-//       format: "der",
-//     }) as Buffer
-//   } catch {}
-
-//   const candidates: Buffer[] = []
-//   candidates.push(createHash("sha256").update(pubRaw).digest())
-//   candidates.push(createHash("sha256").update(pubUncompressed).digest())
-//   if (spki) candidates.push(createHash("sha256").update(spki).digest())
-//   candidates.push(
-//     createHash("sha256").update(pubRaw).update(signature.qe_auth_data).digest(),
-//   )
-//   candidates.push(
-//     createHash("sha256")
-//       .update(pubUncompressed)
-//       .update(signature.qe_auth_data)
-//       .digest(),
-//   )
-
-//   // SGX REPORT structure is 384 bytes; report_data occupies the last 64 bytes (offset 320)
-//   const reportData = signature.qe_report.subarray(320, 384)
-//   const first = reportData.subarray(0, 32)
-//   const second = reportData.subarray(32, 64)
-//   return candidates.some((c) => c.equals(first) || c.equals(second))
-// }}
+  // REPORT size is 384 bytes; report_data is last 64 bytes
+  const reportData = signature.qe_report.subarray(320, 384)
+  const reported = reportData.subarray(0, 32)
+  return digest.equals(reported)
+}
 
 /**
  * Verify the ECDSA-P256 signature inside a TDX v4 quote against the embedded


### PR DESCRIPTION
Implement `verifyQeReportBinding` and enhance `verifyQeReportSignature` to enable full trust chain validation for TDX V4 quotes in tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-4c3bc32b-a665-49e1-a82b-4a462fc8f046">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4c3bc32b-a665-49e1-a82b-4a462fc8f046">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

