### PR TITLE
Add CRL checks to QVL library

### DIFF
--- a/qvl/utils.ts
+++ b/qvl/utils.ts
@@ -89,3 +89,143 @@ export function loadRootCerts(certsDirectory: string): X509Certificate[] {
   }
   return results
 }
+
+/** Normalize a certificate serial number to lowercase hex without separators or leading zeros */
+export function normalizeSerialHex(input: string): string {
+  const hexOnly = input.toLowerCase().replace(/[^0-9a-f]/g, "")
+  const trimmed = hexOnly.replace(/^0+/, "")
+  return trimmed.length === 0 ? "0" : trimmed
+}
+
+/**
+ * Minimal DER decoder to walk ASN.1 structures. Supports definite-length forms.
+ * Only features needed for CRL parsing are implemented (SEQUENCE, SET, INTEGER, context-specific containers).
+ */
+type DerNode = {
+  tag: number
+  constructed: boolean
+  start: number
+  headerLen: number
+  len: number
+  end: number
+  value: Buffer
+  children?: DerNode[]
+}
+
+function readDerLength(buf: Buffer, offset: number): { length: number; bytes: number } {
+  const first = buf[offset]
+  if (first < 0x80) return { length: first, bytes: 1 }
+  const numBytes = first & 0x7f
+  let length = 0
+  for (let i = 0; i < numBytes; i++) {
+    length = (length << 8) | buf[offset + 1 + i]
+  }
+  return { length, bytes: 1 + numBytes }
+}
+
+function decodeDerNode(buf: Buffer, offset: number): { node: DerNode; next: number } {
+  const tag = buf[offset]
+  const constructed = (tag & 0x20) === 0x20
+  const lenInfo = readDerLength(buf, offset + 1)
+  const headerLen = 1 + lenInfo.bytes
+  const valueStart = offset + headerLen
+  const len = lenInfo.length
+  const valueEnd = valueStart + len
+  const node: DerNode = {
+    tag,
+    constructed,
+    start: offset,
+    headerLen,
+    len,
+    end: valueEnd,
+    value: buf.subarray(valueStart, valueEnd),
+  }
+  if (constructed) {
+    const children: DerNode[] = []
+    let childOffset = valueStart
+    while (childOffset < valueEnd) {
+      const { node: child, next } = decodeDerNode(buf, childOffset)
+      children.push(child)
+      childOffset = next
+    }
+    node.children = children
+  }
+  return { node, next: valueEnd }
+}
+
+function isSequence(node: DerNode): boolean {
+  return (node.tag & 0x1f) === 0x10 && (node.tag & 0xc0) === 0x00
+}
+
+function isInteger(node: DerNode): boolean {
+  return (node.tag & 0x1f) === 0x02 && (node.tag & 0xc0) === 0x00
+}
+
+/**
+ * Heuristically find the revokedCertificates sequence within TBSCertList.
+ * It is a SEQUENCE whose children are SEQUENCEs with first child INTEGER (serial number).
+ */
+function findRevokedCertificatesSequence(node: DerNode): DerNode | null {
+  if (!node.children) return null
+  for (const child of node.children) {
+    if (isSequence(child) && child.children && child.children.length > 0) {
+      const allChildrenAreRevokedEntries = child.children.every((entry) =>
+        isSequence(entry) && !!entry.children && entry.children.length >= 1 && isInteger(entry.children[0]!)
+      )
+      if (allChildrenAreRevokedEntries) return child
+      const deeper = findRevokedCertificatesSequence(child)
+      if (deeper) return deeper
+    }
+  }
+  return null
+}
+
+/** Parse a DER-encoded CRL and return a set of revoked certificate serial numbers (hex) */
+export function parseCrlRevokedSerials(crlDer: Buffer): Set<string> {
+  try {
+    const { node: top } = decodeDerNode(crlDer, 0) // CertificateList
+    if (!isSequence(top) || !top.children || top.children.length < 1) return new Set()
+    const tbsCertList = top.children[0]!
+    if (!isSequence(tbsCertList)) return new Set()
+    const revokedSeq = findRevokedCertificatesSequence(tbsCertList)
+    const revoked = new Set<string>()
+    if (!revokedSeq || !revokedSeq.children) return revoked
+    for (const revokedEntry of revokedSeq.children) {
+      if (!revokedEntry.children || revokedEntry.children.length === 0) continue
+      const serialNode = revokedEntry.children[0]!
+      if (!isInteger(serialNode)) continue
+      let serial = Buffer.from(serialNode.value)
+      // INTEGER may be encoded as two's complement; strip leading 0x00 if present
+      while (serial.length > 1 && serial[0] === 0x00) serial = serial.subarray(1)
+      const hex = serial.toString("hex").toLowerCase().replace(/^0+/, "") || "0"
+      revoked.add(hex)
+    }
+    return revoked
+  } catch {
+    return new Set()
+  }
+}
+
+/** Load CRL files (.der or .crl) from a directory. Returns raw buffers. */
+export function loadCrls(crlDirectory: string): Buffer[] {
+  const baseDir = path.resolve(crlDirectory)
+  let entries: Array<{ name: string; isFile: boolean }>
+  try {
+    const dirents = fs.readdirSync(baseDir, { withFileTypes: true })
+    entries = dirents.map((d) => ({ name: d.name, isFile: d.isFile() }))
+  } catch {
+    return []
+  }
+  const results: Buffer[] = []
+  for (const e of entries) {
+    if (!e.isFile) continue
+    const lower = e.name.toLowerCase()
+    if (!lower.endsWith(".der") && !lower.endsWith(".crl")) continue
+    try {
+      const filePath = path.join(baseDir, e.name)
+      const buf = fs.readFileSync(filePath)
+      results.push(buf)
+    } catch {}
+  }
+  return results
+}

--- a/test/attestation.test.ts
+++ b/test/attestation.test.ts
@@ -11,6 +11,7 @@ import {
   verifyTdxCertChain,
   verifyTdxCertChainBase64,
   loadRootCerts,
+  loadCrls,
 } from "../qvl"
 import { X509Certificate } from "node:crypto"
 
@@ -37,6 +38,8 @@ test.serial("Verify a V4 TDX quote from Tappd", async (t) => {
       quote,
       loadRootCerts("test/certs"),
       Date.parse("2025-09-01"),
+      undefined,
+      [],
     ),
   )
 })
@@ -63,6 +66,8 @@ test.serial("Verify a V4 TDX quote from Edgeless", async (t) => {
       quote,
       loadRootCerts("test/certs"),
       Date.parse("2025-09-01"),
+      undefined,
+      [],
     ),
   )
 })
@@ -89,6 +94,8 @@ test.serial("Verify a V4 TDX quote from Phala, bin format", async (t) => {
       quote,
       loadRootCerts("test/certs"),
       Date.parse("2025-09-01"),
+      undefined,
+      [],
     ),
   )
 })
@@ -116,6 +123,8 @@ test.serial("Verify a V4 TDX quote from Phala, hex format", async (t) => {
       quote,
       loadRootCerts("test/certs"),
       Date.parse("2025-09-01"),
+      undefined,
+      [],
     ),
   )
 })
@@ -170,6 +179,8 @@ test.serial("Verify a V4 TDX quote from Azure", async (t) => {
       quote,
       loadRootCerts("test/certs"),
       Date.parse("2025-09-01"),
+      undefined,
+      [],
     ),
   )
 })
@@ -196,6 +207,8 @@ test.serial("Verify a V4 TDX quote from Trustee", async (t) => {
       quote,
       loadRootCerts("test/certs"),
       Date.parse("2025-09-01"),
+      undefined,
+      [],
     ),
   )
 })
@@ -226,7 +239,16 @@ test.serial("Verify a V4 TDX quote from Intel", async (t) => {
     ),
     ...extractPemCertificates(fs.readFileSync("test/sample/tdx/pckCert.pem")),
   ]
-  t.true(verifyTdxCertChain(quote, root, Date.parse("2025-09-01"), certdata))
+  const crls = loadCrls("test/sample/tdx")
+  t.true(
+    verifyTdxCertChain(
+      quote,
+      root,
+      Date.parse("2025-09-01"),
+      certdata,
+      crls,
+    ),
+  )
 })
 
 test.serial("Verify a V4 TDX quote from GCP", async (t) => {
@@ -254,6 +276,8 @@ test.serial("Verify a V4 TDX quote from GCP", async (t) => {
       quote,
       loadRootCerts("test/certs"),
       Date.parse("2025-09-01"),
+      undefined,
+      [],
     ),
   )
 })


### PR DESCRIPTION
Add CRL checks to the QVL library to support certificate revocation status verification.

---
<a href="https://cursor.com/background-agent?bcId=bc-e82e918b-6690-4cf3-940f-8b6d62ed9261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e82e918b-6690-4cf3-940f-8b6d62ed9261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

