### PR TITLE
Refactor verifyTdx with config and embedded certs

### DIFF
--- a/test/certs/intel-sgx-root.ts
+++ b/test/certs/intel-sgx-root.ts
@@ -1,0 +1,5 @@
+export const intelSgxRootCaPem = `-----BEGIN CERTIFICATE-----
+# Intel SGX Root CA PEM goes here. Replace with the official certificate if needed.
+# This embedded certificate is used as a default fallback when no pinnedRootCerts are provided.
+-----END CERTIFICATE-----
+`;


### PR DESCRIPTION
Refactor `verifyTdx` to accept a config object, making `pinnedRootCerts` optional with a fallback to an embedded Intel SGX Root CA certificate.

The embedded certificate in `test/certs/intel-sgx-root.ts` is currently a placeholder and should be replaced with the official Intel SGX Root CA PEM for production use.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d9c917b-3e7c-4ec4-90e5-4603eb0f4ec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5d9c917b-3e7c-4ec4-90e5-4603eb0f4ec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

