### PR TITLE
Debug sgx signature verification in attestation tests

### DIFF
--- a/qvl/structs.ts
+++ b/qvl/structs.ts
@@ -12,7 +12,7 @@ export const QuoteHeader = new Struct("QuoteHeader")
 
 export const SgxReportBody = new Struct("SgxReportBody")
   .Buffer("cpu_svn", 16)
-  .UInt32LE("misc_select", 32)
+  .UInt32LE("misc_select")
   .Buffer("reserved1", 28)
   .Buffer("attributes", 16)
   .Buffer("mr_enclave", 32)


### PR DESCRIPTION
Correct `SgxReportBody` struct layout and add a fallback for SGX quote signature verification to handle little-endian r/s values.

SGX signatures were failing verification because the `misc_select` field in `SgxReportBody` was incorrectly sized, leading to an incorrect signed region. Additionally, some SGX implementations serialize the `r` and `s` components of the ECDSA signature in little-endian format, which was not being handled.

---
<a href="https://cursor.com/background-agent?bcId=bc-e15bd33b-3ad7-4740-8434-000c7cdd7077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e15bd33b-3ad7-4740-8434-000c7cdd7077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

