### PR TITLE
Make qvl package browser and Node.js compatible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ra-https",
       "version": "0.0.0",
       "dependencies": {
+        "@peculiar/webcrypto": "^1.5.0",
         "@peculiar/x509": "^1.14.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -1334,6 +1335,34 @@
         "@peculiar/asn1-x509": "^2.5.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.5.0.tgz",
+      "integrity": "sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2",
+        "webcrypto-core": "^1.8.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
       }
     },
     "node_modules/@peculiar/x509": {
@@ -6394,6 +6423,19 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webcrypto-core": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.1.tgz",
+      "integrity": "sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.7.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "ava"
   },
   "dependencies": {
+    "@peculiar/webcrypto": "^1.5.0",
     "@peculiar/x509": "^1.14.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",

--- a/qvl/utils.ts
+++ b/qvl/utils.ts
@@ -1,4 +1,8 @@
-import { createHash, X509Certificate } from "crypto"
+import { Crypto } from "@peculiar/webcrypto"
+import { X509Certificate, cryptoProvider } from "@peculiar/x509"
+
+const crypto = new Crypto()
+cryptoProvider.set(crypto)
 
 export const hex = (b: Buffer) => b.toString("hex")
 
@@ -49,8 +53,9 @@ export function extractPemCertificates(certData: Buffer): string[] {
 }
 
 /** Compute SHA-256 of a certificate's DER bytes, lowercase hex */
-export function computeCertSha256Hex(cert: X509Certificate): string {
-  return createHash("sha256").update(cert.raw).digest("hex")
+export async function computeCertSha256Hex(cert: X509Certificate): Promise<string> {
+  const hashBuffer = await crypto.subtle.digest("SHA-256", cert.rawData)
+  return Buffer.from(hashBuffer).toString("hex")
 }
 
 /** Normalize a certificate serial number to uppercase hex without delimiters or leading zeros */

--- a/qvl/verifyTdx.ts
+++ b/qvl/verifyTdx.ts
@@ -1,15 +1,14 @@
+import { Crypto } from "@peculiar/webcrypto"
 import {
-  createHash,
-  createPublicKey,
-  createVerify,
   X509Certificate,
-} from "crypto"
-import {
-  X509Certificate as ExtX509Certificate,
   BasicConstraintsExtension,
   KeyUsagesExtension,
   KeyUsageFlags,
+  cryptoProvider,
 } from "@peculiar/x509"
+
+const crypto = new Crypto()
+cryptoProvider.set(crypto)
 
 import {
   getTdx10SignedRegion,
@@ -43,7 +42,7 @@ export const DEFAULT_PINNED_ROOT_CERTS: X509Certificate[] = [
  *
  * Optional: accepts `extraCertdata`, which is used if `quote` is missing certdata.
  */
-export function verifyTdx(quote: Buffer, config?: VerifyConfig) {
+export async function verifyTdx(quote: Buffer, config?: VerifyConfig) {
   if (
     config !== undefined &&
     (typeof config !== "object" || Array.isArray(config))
@@ -57,14 +56,14 @@ export function verifyTdx(quote: Buffer, config?: VerifyConfig) {
   const crls = config?.crls
   const { signature, header } = parseTdxQuote(quote)
   const certs = extractPemCertificates(signature.cert_data)
-  let { status, root } = verifyPCKChain(certs, date ?? +new Date(), crls)
+  let { status, root } = await verifyPCKChain(certs, date ?? +new Date(), crls)
 
   // Use fallback certs, only if certdata is not provided
   if (!root && certs.length === 0) {
     if (!extraCertdata) {
       throw new Error("verifyTdx: missing certdata")
     }
-    const fallback = verifyPCKChain(extraCertdata, date ?? +new Date(), crls)
+    const fallback = await verifyPCKChain(extraCertdata, date ?? +new Date(), crls)
     status = fallback.status
     root = fallback.root
   }
@@ -82,8 +81,8 @@ export function verifyTdx(quote: Buffer, config?: VerifyConfig) {
   }
 
   // Check against the pinned root certificates
-  const candidateRootHash = computeCertSha256Hex(root)
-  const knownRootHashes = new Set(pinnedRootCerts.map(computeCertSha256Hex))
+  const candidateRootHash = await computeCertSha256Hex(root)
+  const knownRootHashes = new Set(await Promise.all(pinnedRootCerts.map(computeCertSha256Hex)))
   const rootIsValid = knownRootHashes.has(candidateRootHash)
   if (!rootIsValid) {
     throw new Error("verifyTdx: invalid root")
@@ -98,21 +97,21 @@ export function verifyTdx(quote: Buffer, config?: VerifyConfig) {
   if (signature.cert_data_type !== 5) {
     throw new Error("verifyTdx: only PCK cert_data is supported")
   }
-  if (!verifyTdxQeReportSignature(quote, extraCertdata)) {
+  if (!(await verifyTdxQeReportSignature(quote, extraCertdata))) {
     throw new Error("verifyTdx: invalid qe report signature")
   }
-  if (!verifyTdxQeReportBinding(quote)) {
+  if (!(await verifyTdxQeReportBinding(quote))) {
     throw new Error("verifyTdx: invalid qe report binding")
   }
-  if (!verifyTdxQuoteSignature(quote)) {
+  if (!(await verifyTdxQuoteSignature(quote))) {
     throw new Error("verifyTdx: invalid signature over quote")
   }
 
   return true
 }
 
-export function verifyTdxBase64(quote: string, config?: VerifyConfig) {
-  return verifyTdx(Buffer.from(quote, "base64"), config)
+export async function verifyTdxBase64(quote: string, config?: VerifyConfig) {
+  return await verifyTdx(Buffer.from(quote, "base64"), config)
 }
 
 /**
@@ -121,23 +120,19 @@ export function verifyTdxBase64(quote: string, config?: VerifyConfig) {
  * - Expects at least two certificates.
  * - Checks the validity window of each certificate.
  */
-export function verifyPCKChain(
+export async function verifyPCKChain(
   certData: string[],
   verifyAtTimeMs: number | null,
   crls?: Buffer[],
-): {
+): Promise<{
   status: "valid" | "invalid" | "expired" | "revoked"
   root: X509Certificate | null
   chain: X509Certificate[]
-} {
+}> {
   if (certData.length === 0) return { status: "invalid", root: null, chain: [] }
 
-  // Build paired views for each certificate (Node for chaining, Peculiar for extensions)
-  const pairs = certData.map((pem) => ({
-    node: new X509Certificate(pem),
-    ext: new ExtX509Certificate(pem),
-  }))
-  const certs = pairs.map((p) => p.node)
+  // Build certificate objects using @peculiar/x509
+  const certs = certData.map((pem) => new X509Certificate(pem))
 
   // Identify leaf (not an issuer of any other provided cert)
   let leaf: X509Certificate | undefined
@@ -169,8 +164,8 @@ export function verifyPCKChain(
 
   // Check for expired or not-yet-valid certificates
   for (const c of chain) {
-    const notBefore = new Date(c.validFrom).getTime()
-    const notAfter = new Date(c.validTo).getTime()
+    const notBefore = c.notBefore.getTime()
+    const notAfter = c.notAfter.getTime()
     if (
       verifyAtTimeMs !== null &&
       !(notBefore <= verifyAtTimeMs && verifyAtTimeMs <= notAfter)
@@ -184,7 +179,7 @@ export function verifyPCKChain(
     const child = chain[i]
     const parent = chain[i + 1]
     try {
-      if (!child.verify(parent.publicKey)) {
+      if (!(await child.verify(parent))) {
         return { status: "invalid", root: null, chain: [] }
       }
     } catch {
@@ -196,7 +191,7 @@ export function verifyPCKChain(
   const terminal = chain[chain.length - 1]
   if (terminal && terminal.subject === terminal.issuer) {
     try {
-      if (!terminal.verify(terminal.publicKey)) {
+      if (!(await terminal.verify(terminal))) {
         return { status: "invalid", root: null, chain: [] }
       }
     } catch {
@@ -210,52 +205,39 @@ export function verifyPCKChain(
   // - End-entity leaf must assert ca = false if basicConstraints present
   // - End-entity with keyUsage must include digitalSignature (used for ECDSA signing)
   // - Respect pathLenConstraint when present on CA certs
-  const getExtForNode = (node: X509Certificate): ExtX509Certificate | null => {
-    const idx = certs.indexOf(node)
-    if (idx === -1) return null
-    return pairs[idx].ext
-  }
 
   // Determine CA flag of each cert in the path using BasicConstraints if present
   const isCAInChain: boolean[] = chain.map((node) => {
-    const extCert = getExtForNode(node)
-    if (!extCert) return false
-    const bc = extCert.getExtension(BasicConstraintsExtension)
+    const bc = node.getExtension(BasicConstraintsExtension)
     return bc ? !!bc.ca : false
   })
 
   // Leaf checks
   const leafNode = chain[0]
-  const extCert = getExtForNode(leafNode)
-  if (extCert) {
-    const bc = extCert.getExtension(BasicConstraintsExtension)
-    if (bc && bc.ca) {
+  const bc = leafNode.getExtension(BasicConstraintsExtension)
+  if (bc && bc.ca) {
+    return { status: "invalid", root: null, chain: [] }
+  }
+  const ku = leafNode.getExtension(KeyUsagesExtension)
+  if (ku) {
+    const hasDigitalSignature =
+      (ku.usages & KeyUsageFlags.digitalSignature) !== 0
+    if (!hasDigitalSignature) {
       return { status: "invalid", root: null, chain: [] }
-    }
-    const ku = extCert.getExtension(KeyUsagesExtension)
-    if (ku) {
-      const hasDigitalSignature =
-        (ku.usages & KeyUsageFlags.digitalSignature) !== 0
-      if (!hasDigitalSignature) {
-        return { status: "invalid", root: null, chain: [] }
-      }
     }
   }
 
   // CA and pathLen checks for all issuers in the chain
   for (let i = 1; i < chain.length; i++) {
     const issuerNode = chain[i]
-    const extCert = getExtForNode(issuerNode)
-    if (!extCert) continue
-
-    const bc = extCert.getExtension(BasicConstraintsExtension)
+    const bc = issuerNode.getExtension(BasicConstraintsExtension)
     // CA certs must assert CA=true
     if (!bc || !bc.ca) {
       return { status: "invalid", root: null, chain: [] }
     }
 
     // keyUsage, if present, must include keyCertSign
-    const ku = extCert.getExtension(KeyUsagesExtension)
+    const ku = issuerNode.getExtension(KeyUsagesExtension)
     if (ku) {
       const canSignCert = (ku.usages & KeyUsageFlags.keyCertSign) !== 0
       if (!canSignCert) {
@@ -301,10 +283,10 @@ export function verifyPCKChain(
  * This verifies the PCK leaf certificate public key, against qe_report_signature
  * and the qe_report body (384 bytes).
  */
-export function verifyTdxQeReportSignature(
+export async function verifyTdxQeReportSignature(
   quoteInput: string | Buffer,
   extraCerts?: string[],
-): boolean {
+): Promise<boolean> {
   const quoteBytes = Buffer.isBuffer(quoteInput)
     ? quoteInput
     : Buffer.from(quoteInput, "base64")
@@ -325,7 +307,7 @@ export function verifyTdxQeReportSignature(
   }
   if (certs.length === 0) return false
 
-  const { chain } = verifyPCKChain(certs, null)
+  const { chain } = await verifyPCKChain(certs, null)
 
   if (chain.length === 0) return false
 
@@ -333,19 +315,32 @@ export function verifyTdxQeReportSignature(
   const pckLeafKey = pckLeafCert.publicKey
 
   // Following Intel's C++ implementation:
-  // 1. Convert raw ECDSA signature (64 bytes: r||s) to DER format
+  // 1. Use raw ECDSA signature (64 bytes: r||s) directly
   // 2. Verify with SHA-256 against the raw QE report blob (384 bytes)
   try {
-    const derSignature = encodeEcdsaSignatureToDer(
-      signature.qe_report_signature,
+    // Use the raw signature directly - webcrypto expects raw format for ECDSA
+    const rawSignature = signature.qe_report_signature
+    
+    // Import the public key for verification
+    const publicKey = await crypto.subtle.importKey(
+      "spki",
+      pckLeafKey.rawData,
+      { name: "ECDSA", namedCurve: "P-256" },
+      false,
+      ["verify"]
     )
-    const verifier = createVerify("sha256")
-    verifier.update(signature.qe_report)
-    verifier.end()
-    const result = verifier.verify(pckLeafKey, derSignature)
+    
+    // Verify the signature
+    const result = await crypto.subtle.verify(
+      { name: "ECDSA", hash: "SHA-256" },
+      publicKey,
+      rawSignature,
+      signature.qe_report
+    )
 
     return result
-  } catch {
+  } catch (error) {
+    console.error("TDX QE report signature verification error:", error)
     return false
   }
 }
@@ -358,7 +353,7 @@ export function verifyTdxQeReportSignature(
  *
  * Accept several reasonable variants to accommodate ecosystem differences.
  */
-export function verifyTdxQeReportBinding(quoteInput: string | Buffer): boolean {
+export async function verifyTdxQeReportBinding(quoteInput: string | Buffer): Promise<boolean> {
   const quoteBytes = Buffer.isBuffer(quoteInput)
     ? quoteInput
     : Buffer.from(quoteInput, "base64")
@@ -368,16 +363,11 @@ export function verifyTdxQeReportBinding(quoteInput: string | Buffer): boolean {
     throw new Error("Unsupported quote version")
   if (!signature.qe_report_present) throw new Error("Missing QE report")
 
-  const hashedPubkey = createHash("sha256")
-    .update(signature.attestation_public_key)
-    .update(signature.qe_auth_data)
-    .digest()
-  const hashedUncompressedPubkey = createHash("sha256")
-    .update(
-      Buffer.concat([Buffer.from([0x04]), signature.attestation_public_key]),
-    )
-    .update(signature.qe_auth_data)
-    .digest()
+  const combinedData = Buffer.concat([signature.attestation_public_key, signature.qe_auth_data])
+  const hashedPubkey = await crypto.subtle.digest("SHA-256", combinedData)
+  
+  const uncompressedData = Buffer.concat([Buffer.from([0x04]), signature.attestation_public_key, signature.qe_auth_data])
+  const hashedUncompressedPubkey = await crypto.subtle.digest("SHA-256", uncompressedData)
 
   // QE report is 384 bytes; report_data occupies the last 64 bytes (offset 320).
   // The attestation_public_key should be embedded in the first half.
@@ -385,8 +375,8 @@ export function verifyTdxQeReportBinding(quoteInput: string | Buffer): boolean {
   const reportDataEmbed = reportData.subarray(0, 32)
 
   return (
-    hashedPubkey.equals(reportDataEmbed) ||
-    hashedUncompressedPubkey.equals(reportDataEmbed)
+    Buffer.from(hashedPubkey).equals(reportDataEmbed) ||
+    Buffer.from(hashedUncompressedPubkey).equals(reportDataEmbed)
   )
 }
 
@@ -395,7 +385,7 @@ export function verifyTdxQeReportBinding(quoteInput: string | Buffer): boolean {
  * with a ECDSA-P256 signature. This checks only the quote signature itself and
  * does not validate the certificate chain, QE report, CRLs, TCBs, etc.
  */
-export function verifyTdxQuoteSignature(quoteInput: string | Buffer): boolean {
+export async function verifyTdxQuoteSignature(quoteInput: string | Buffer): Promise<boolean> {
   const quoteBytes = Buffer.isBuffer(quoteInput)
     ? quoteInput
     : Buffer.from(quoteInput, "base64")
@@ -412,7 +402,6 @@ export function verifyTdxQuoteSignature(quoteInput: string | Buffer): boolean {
   }
 
   const rawSig = signature.ecdsa_signature
-  const derSig = encodeEcdsaSignatureToDer(rawSig)
 
   const pub = signature.attestation_public_key
   if (pub.length !== 64) {
@@ -428,10 +417,20 @@ export function verifyTdxQuoteSignature(quoteInput: string | Buffer): boolean {
     y,
   } as const
 
-  const publicKey = createPublicKey({ key: jwk, format: "jwk" })
+  // Import the public key from JWK format
+  const publicKey = await crypto.subtle.importKey(
+    "jwk",
+    jwk,
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["verify"]
+  )
 
-  const verifier = createVerify("sha256")
-  verifier.update(message)
-  verifier.end()
-  return verifier.verify(publicKey, derSig)
+  // Verify the signature
+  return await crypto.subtle.verify(
+    { name: "ECDSA", hash: "SHA-256" },
+    publicKey,
+    rawSig,
+    message
+  )
 }

--- a/test/qvl.test.ts
+++ b/test/qvl.test.ts
@@ -1,5 +1,5 @@
 import test from "ava"
-import { X509Certificate } from "node:crypto"
+import { X509Certificate } from "@peculiar/x509"
 import fs from "node:fs"
 
 import {
@@ -37,7 +37,7 @@ test.serial("Verify a V4 TDX quote from Tappd", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
 
-  t.true(verifyTdx(quote, { date: BASE_TIME, crls: [] }))
+  t.true(await verifyTdx(quote, { date: BASE_TIME, crls: [] }))
 })
 
 test.serial("Verify a V4 TDX quote from Edgeless", async (t) => {
@@ -57,7 +57,7 @@ test.serial("Verify a V4 TDX quote from Edgeless", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
 
-  t.true(verifyTdx(quote, { date: BASE_TIME, crls: [] }))
+  t.true(await verifyTdx(quote, { date: BASE_TIME, crls: [] }))
 })
 
 test.serial("Verify a V4 TDX quote from Phala, bin format", async (t) => {
@@ -77,7 +77,7 @@ test.serial("Verify a V4 TDX quote from Phala, bin format", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
 
-  t.true(verifyTdx(quote, { date: BASE_TIME, crls: [] }))
+  t.true(await verifyTdx(quote, { date: BASE_TIME, crls: [] }))
 })
 
 test.serial("Verify a V4 TDX quote from Phala, hex format", async (t) => {
@@ -98,7 +98,7 @@ test.serial("Verify a V4 TDX quote from Phala, hex format", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
 
-  t.true(verifyTdx(quote, { date: BASE_TIME, crls: [] }))
+  t.true(await verifyTdx(quote, { date: BASE_TIME, crls: [] }))
 })
 
 test.serial("Verify a V4 TDX quote from MoeMahhouk", async (t) => {
@@ -120,7 +120,7 @@ test.serial("Verify a V4 TDX quote from MoeMahhouk", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
 
-  t.true(verifyTdx(quote, { date: BASE_TIME, crls: [] }))
+  t.true(await verifyTdx(quote, { date: BASE_TIME, crls: [] }))
 })
 
 test.serial("Verify a V4 TDX quote from Azure", async (t) => {
@@ -140,7 +140,7 @@ test.serial("Verify a V4 TDX quote from Azure", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
 
-  t.true(verifyTdxBase64(quote, { date: BASE_TIME, crls: [] }))
+  t.true(await verifyTdxBase64(quote, { date: BASE_TIME, crls: [] }))
 })
 
 test.serial("Verify a V4 TDX quote from Trustee", async (t) => {
@@ -160,7 +160,7 @@ test.serial("Verify a V4 TDX quote from Trustee", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
 
-  t.true(verifyTdx(quote, { date: BASE_TIME, crls: [] }))
+  t.true(await verifyTdx(quote, { date: BASE_TIME, crls: [] }))
 })
 
 test.serial("Verify a V4 TDX quote from ZKDCAP", async (t) => {
@@ -180,7 +180,7 @@ test.serial("Verify a V4 TDX quote from ZKDCAP", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
 
-  t.true(verifyTdx(quote, { date: BASE_TIME, crls: [] }))
+  t.true(await verifyTdx(quote, { date: BASE_TIME, crls: [] }))
 })
 
 test.serial("Verify a V4 TDX quote from Intel", async (t) => {
@@ -219,7 +219,7 @@ test.serial("Verify a V4 TDX quote from Intel", async (t) => {
   ]
 
   t.true(
-    verifyTdx(quote, {
+    await verifyTdx(quote, {
       pinnedRootCerts: [new X509Certificate(root[0])],
       date: BASE_TIME,
       extraCertdata: certdata,
@@ -248,7 +248,7 @@ test.serial("Verify a V4 TDX quote from GCP", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
 
-  t.true(verifyTdxBase64(quote, { date: BASE_TIME, crls: [] }))
+  t.true(await verifyTdxBase64(quote, { date: BASE_TIME, crls: [] }))
 })
 
 test.serial("Verify a V5 TDX quote from Trustee", async (t) => {
@@ -268,7 +268,7 @@ test.serial("Verify a V5 TDX quote from Trustee", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
 
-  t.true(verifyTdx(quote, { date: BASE_TIME, crls: [] }))
+  t.true(await verifyTdx(quote, { date: BASE_TIME, crls: [] }))
 })
 
 test.serial("Parse an SGX quote from Intel, no quote signature", async (t) => {
@@ -306,8 +306,8 @@ test.serial("Parse an SGX quote from Intel, no quote signature", async (t) => {
     fs.readFileSync("test/sample/sgx/intermediateCaCrl.der"),
   ]
 
-  t.throws(() =>
-    verifySgx(quote, {
+  t.throwsAsync(async () =>
+    await verifySgx(quote, {
       pinnedRootCerts: [new X509Certificate(root[0])],
       date: BASE_TIME,
       crls,
@@ -330,7 +330,7 @@ test.serial("Verify an SGX quote from Occlum", async (t) => {
   t.is(hex(body.mr_enclave), expectedMrEnclave)
   t.is(hex(body.report_data), expectedReportData)
 
-  t.true(verifySgx(quote, { date: BASE_TIME, crls: [] }))
+  t.true(await verifySgx(quote, { date: BASE_TIME, crls: [] }))
 })
 
 test.serial("Verify an SGX quote from chinenyeokafor", async (t) => {
@@ -347,7 +347,7 @@ test.serial("Verify an SGX quote from chinenyeokafor", async (t) => {
   t.is(hex(body.mr_enclave), expectedMrEnclave)
   t.is(hex(body.report_data), expectedReportData)
 
-  t.true(verifySgx(quote, { date: BASE_TIME, crls: [] }))
+  t.true(await verifySgx(quote, { date: BASE_TIME, crls: [] }))
 })
 
 test.serial("Verify an SGX quote from TLSN, quote9", async (t) => {
@@ -364,7 +364,7 @@ test.serial("Verify an SGX quote from TLSN, quote9", async (t) => {
   t.is(hex(body.mr_enclave), expectedMrEnclave)
   t.is(hex(body.report_data), expectedReportData)
 
-  t.true(verifySgx(quote, { date: BASE_TIME, crls: [] }))
+  t.true(await verifySgx(quote, { date: BASE_TIME, crls: [] }))
 })
 
 test.serial("Verify an SGX quote from TLSN, quote_dev", async (t) => {
@@ -381,7 +381,7 @@ test.serial("Verify an SGX quote from TLSN, quote_dev", async (t) => {
   t.is(hex(body.mr_enclave), expectedMrEnclave)
   t.is(hex(body.report_data), expectedReportData)
 
-  t.true(verifySgx(quote, { date: BASE_TIME, crls: [] }))
+  t.true(await verifySgx(quote, { date: BASE_TIME, crls: [] }))
 })
 
 // ---------------------- Negative tests for invalid scenarios ----------------------
@@ -476,24 +476,24 @@ function getGcpQuoteBase64(): string {
   return data.tdx.quote as string
 }
 
-function getGcpCertPems(): {
+async function getGcpCertPems(): Promise<{
   leaf: string
   intermediate: string
   root: string
   all: string[]
-} {
+}> {
   const quoteB64 = getGcpQuoteBase64()
   const { signature } = parseTdxQuoteBase64(quoteB64)
   const pems = extractPemCertificates(signature.cert_data)
-  const { chain } = verifyPCKChain(pems, null)
+  const { chain } = await verifyPCKChain(pems, null)
   const hashToPem = new Map<string, string>()
   for (const pem of pems) {
-    const h = computeCertSha256Hex(new X509Certificate(pem))
+    const h = await computeCertSha256Hex(new X509Certificate(pem))
     hashToPem.set(h, pem)
   }
-  const leafPem = hashToPem.get(computeCertSha256Hex(chain[0]))!
-  const intermediatePem = hashToPem.get(computeCertSha256Hex(chain[1]))!
-  const rootPem = hashToPem.get(computeCertSha256Hex(chain[2]))!
+  const leafPem = hashToPem.get(await computeCertSha256Hex(chain[0]))!
+  const intermediatePem = hashToPem.get(await computeCertSha256Hex(chain[1]))!
+  const rootPem = hashToPem.get(await computeCertSha256Hex(chain[2]))!
   return {
     leaf: leafPem,
     intermediate: intermediatePem,
@@ -504,8 +504,8 @@ function getGcpCertPems(): {
 
 test.serial("Reject a V4 TDX quote, missing root cert", async (t) => {
   const quoteB64 = getGcpQuoteBase64()
-  const err = t.throws(() =>
-    verifyTdxBase64(quoteB64, {
+  const err = await t.throwsAsync(async () =>
+    await verifyTdxBase64(quoteB64, {
       pinnedRootCerts: [],
       date: BASE_TIME,
       crls: [],
@@ -518,10 +518,10 @@ test.serial("Reject a V4 TDX quote, missing root cert", async (t) => {
 test.serial("Reject a V4 TDX quote, missing intermediate cert", async (t) => {
   const quoteB64 = getGcpQuoteBase64()
   const quoteBuf = Buffer.from(quoteB64, "base64")
-  const { leaf, root } = getGcpCertPems()
+  const { leaf, root } = await getGcpCertPems()
   const noEmbedded = rebuildQuoteWithCertData(quoteBuf, Buffer.alloc(0))
-  const err = t.throws(() =>
-    verifyTdx(noEmbedded, {
+  const err = await t.throwsAsync(async () =>
+    await verifyTdx(noEmbedded, {
       date: BASE_TIME,
       extraCertdata: [leaf, root],
       crls: [],
@@ -534,10 +534,10 @@ test.serial("Reject a V4 TDX quote, missing intermediate cert", async (t) => {
 test.serial("Reject a V4 TDX quote, missing leaf cert", async (t) => {
   const quoteB64 = getGcpQuoteBase64()
   const quoteBuf = Buffer.from(quoteB64, "base64")
-  const { intermediate, root } = getGcpCertPems()
+  const { intermediate, root } = await getGcpCertPems()
   const noEmbedded = rebuildQuoteWithCertData(quoteBuf, Buffer.alloc(0))
-  const err = t.throws(() =>
-    verifyTdx(noEmbedded, {
+  const err = await t.throwsAsync(async () =>
+    await verifyTdx(noEmbedded, {
       date: BASE_TIME,
       extraCertdata: [intermediate, root],
       crls: [],
@@ -549,14 +549,14 @@ test.serial("Reject a V4 TDX quote, missing leaf cert", async (t) => {
 
 test.serial("Reject a V4 TDX quote, revoked root cert", async (t) => {
   const quoteB64 = getGcpQuoteBase64()
-  const { root } = getGcpCertPems()
+  const { root } = await getGcpCertPems()
   const rootSerial = new X509Certificate(root).serialNumber
     .replace(/[^0-9A-F]/g, "")
     .toUpperCase()
     .replace(/^0+(?=[0-9A-F])/g, "")
   const crl = buildCRLWithSerials([rootSerial])
-  const err = t.throws(() =>
-    verifyTdxBase64(quoteB64, { date: BASE_TIME, crls: [crl] }),
+  const err = await t.throwsAsync(async () =>
+    await verifyTdxBase64(quoteB64, { date: BASE_TIME, crls: [crl] }),
   )
   t.truthy(err)
   t.regex(err!.message, /revoked certificate in cert chain/i)
@@ -564,14 +564,14 @@ test.serial("Reject a V4 TDX quote, revoked root cert", async (t) => {
 
 test.serial("Reject a V4 TDX quote, revoked intermediate cert", async (t) => {
   const quoteB64 = getGcpQuoteBase64()
-  const { intermediate } = getGcpCertPems()
+  const { intermediate } = await getGcpCertPems()
   const serial = new X509Certificate(intermediate).serialNumber
     .replace(/[^0-9A-F]/g, "")
     .toUpperCase()
     .replace(/^0+(?=[0-9A-F])/g, "")
   const crl = buildCRLWithSerials([serial])
-  const err = t.throws(() =>
-    verifyTdxBase64(quoteB64, { date: BASE_TIME, crls: [crl] }),
+  const err = await t.throwsAsync(async () =>
+    await verifyTdxBase64(quoteB64, { date: BASE_TIME, crls: [crl] }),
   )
   t.truthy(err)
   t.regex(err!.message, /revoked certificate in cert chain/i)
@@ -579,14 +579,14 @@ test.serial("Reject a V4 TDX quote, revoked intermediate cert", async (t) => {
 
 test.serial("Reject a V4 TDX quote, revoked leaf cert", async (t) => {
   const quoteB64 = getGcpQuoteBase64()
-  const { leaf } = getGcpCertPems()
+  const { leaf } = await getGcpCertPems()
   const serial = new X509Certificate(leaf).serialNumber
     .replace(/[^0-9A-F]/g, "")
     .toUpperCase()
     .replace(/^0+(?=[0-9A-F])/g, "")
   const crl = buildCRLWithSerials([serial])
-  const err = t.throws(() =>
-    verifyTdxBase64(quoteB64, { date: BASE_TIME, crls: [crl] }),
+  const err = await t.throwsAsync(async () =>
+    await verifyTdxBase64(quoteB64, { date: BASE_TIME, crls: [crl] }),
   )
   t.truthy(err)
   t.regex(err!.message, /revoked certificate in cert chain/i)
@@ -595,11 +595,11 @@ test.serial("Reject a V4 TDX quote, revoked leaf cert", async (t) => {
 test.serial("Reject a V4 TDX quote, invalid root self-signature", async (t) => {
   const quoteB64 = getGcpQuoteBase64()
   const quoteBuf = Buffer.from(quoteB64, "base64")
-  const { leaf, intermediate, root } = getGcpCertPems()
+  const { leaf, intermediate, root } = await getGcpCertPems()
   const tamperedRoot = tamperPemSignature(root)
   const noEmbedded = rebuildQuoteWithCertData(quoteBuf, Buffer.alloc(0))
-  const err = t.throws(() =>
-    verifyTdx(noEmbedded, {
+  const err = await t.throwsAsync(async () =>
+    await verifyTdx(noEmbedded, {
       date: BASE_TIME,
       extraCertdata: [leaf, intermediate, tamperedRoot],
       crls: [],
@@ -614,11 +614,11 @@ test.serial(
   async (t) => {
     const quoteB64 = getGcpQuoteBase64()
     const quoteBuf = Buffer.from(quoteB64, "base64")
-    const { leaf, intermediate, root } = getGcpCertPems()
+    const { leaf, intermediate, root } = await getGcpCertPems()
     const tamperedIntermediate = tamperPemSignature(intermediate)
     const noEmbedded = rebuildQuoteWithCertData(quoteBuf, Buffer.alloc(0))
-    const err = t.throws(() =>
-      verifyTdx(noEmbedded, {
+    const err = await t.throwsAsync(async () =>
+      await verifyTdx(noEmbedded, {
         date: BASE_TIME,
         extraCertdata: [leaf, tamperedIntermediate, root],
         crls: [],
@@ -632,11 +632,11 @@ test.serial(
 test.serial("Reject a V4 TDX quote, invalid leaf cert signature", async (t) => {
   const quoteB64 = getGcpQuoteBase64()
   const quoteBuf = Buffer.from(quoteB64, "base64")
-  const { leaf, intermediate, root } = getGcpCertPems()
+  const { leaf, intermediate, root } = await getGcpCertPems()
   const tamperedLeaf = tamperPemSignature(leaf)
   const noEmbedded = rebuildQuoteWithCertData(quoteBuf, Buffer.alloc(0))
-  const err = t.throws(() =>
-    verifyTdx(noEmbedded, {
+  const err = await t.throwsAsync(async () =>
+    await verifyTdx(noEmbedded, {
       date: BASE_TIME,
       extraCertdata: [tamperedLeaf, intermediate, root],
       crls: [],
@@ -667,7 +667,7 @@ test.serial("Reject a V4 TDX quote, incorrect QE signature", async (t) => {
     ),
     sigData,
   ])
-  const err = t.throws(() => verifyTdx(mutated, { date: BASE_TIME, crls: [] }))
+  const err = await t.throwsAsync(async () => await verifyTdx(mutated, { date: BASE_TIME, crls: [] }))
   t.truthy(err)
   t.regex(err!.message, /invalid qe report signature/i)
 })
@@ -693,7 +693,7 @@ test.serial("Reject a V4 TDX quote, incorrect QE binding", async (t) => {
     ),
     sigData,
   ])
-  const err = t.throws(() => verifyTdx(mutated, { date: BASE_TIME, crls: [] }))
+  const err = await t.throwsAsync(async () => await verifyTdx(mutated, { date: BASE_TIME, crls: [] }))
   t.truthy(err)
   t.regex(err!.message, /invalid qe report binding/i)
 })
@@ -719,7 +719,7 @@ test.serial("Reject a V4 TDX quote, incorrect TD signature", async (t) => {
     ),
     sigData,
   ])
-  const err = t.throws(() => verifyTdx(mutated, { date: BASE_TIME, crls: [] }))
+  const err = await t.throwsAsync(async () => await verifyTdx(mutated, { date: BASE_TIME, crls: [] }))
   t.truthy(err)
   t.regex(err!.message, /invalid signature over quote/i)
 })
@@ -730,8 +730,8 @@ test.serial(
     const quoteB64 = getGcpQuoteBase64()
     const base = Buffer.from(quoteB64, "base64")
     const noEmbedded = rebuildQuoteWithCertData(base, Buffer.alloc(0))
-    const err = t.throws(() =>
-      verifyTdx(noEmbedded, { date: BASE_TIME, crls: [] }),
+    const err = await t.throwsAsync(async () =>
+      await verifyTdx(noEmbedded, { date: BASE_TIME, crls: [] }),
     )
     t.truthy(err)
     t.regex(err!.message, /missing certdata/i)
@@ -742,7 +742,7 @@ test.serial(
   "Reject a V4 TDX quote, expired or not-yet-valid certificate chain",
   async (t) => {
     const quoteB64 = getGcpQuoteBase64()
-    const err = t.throws(() => verifyTdxBase64(quoteB64, { date: 0, crls: [] }))
+    const err = await t.throwsAsync(async () => await verifyTdxBase64(quoteB64, { date: 0, crls: [] }))
     t.truthy(err)
     t.regex(err!.message, /expired cert chain/i)
   },
@@ -754,7 +754,7 @@ test.serial("Reject a V4 TDX quote, unsupported TEE type", async (t) => {
   const mutated = Buffer.from(original)
   // header.tee_type at offset 4 (UInt32LE)
   mutated.writeUInt32LE(0, 4)
-  const err = t.throws(() => verifyTdx(mutated, { date: BASE_TIME, crls: [] }))
+  const err = await t.throwsAsync(async () => await verifyTdx(mutated, { date: BASE_TIME, crls: [] }))
   t.truthy(err)
   t.regex(err!.message, /only tdx is supported/i)
 })
@@ -767,8 +767,8 @@ test.serial(
     const mutated = Buffer.from(original)
     // header.att_key_type at offset 2 (UInt16LE)
     mutated.writeUInt16LE(1, 2)
-    const err = t.throws(() =>
-      verifyTdx(mutated, { date: BASE_TIME, crls: [] }),
+    const err = await t.throwsAsync(async () =>
+      await verifyTdx(mutated, { date: BASE_TIME, crls: [] }),
     )
     t.truthy(err)
     t.regex(err!.message, /only ECDSA att_key_type is supported/i)
@@ -802,7 +802,7 @@ test.serial("Reject a V4 TDX quote, unsupported cert_data_type", async (t) => {
     sigData,
   ])
 
-  const err = t.throws(() => verifyTdx(mutated, { date: BASE_TIME, crls: [] }))
+  const err = await t.throwsAsync(async () => await verifyTdx(mutated, { date: BASE_TIME, crls: [] }))
   t.truthy(err)
   t.regex(err!.message, /only PCK cert_data is supported/i)
 })
@@ -812,8 +812,8 @@ test.serial(
   async (t) => {
     const quoteB64 = getGcpQuoteBase64()
     const early = Date.parse("2000-01-01")
-    const err = t.throws(() =>
-      verifyTdxBase64(quoteB64, { date: early, crls: [] }),
+    const err = await t.throwsAsync(async () =>
+      await verifyTdxBase64(quoteB64, { date: early, crls: [] }),
     )
     t.truthy(err)
     t.regex(err!.message, /expired cert chain, or not yet valid/i)
@@ -825,8 +825,8 @@ test.serial(
   async (t) => {
     const quoteB64 = getGcpQuoteBase64()
     const late = Date.parse("2100-01-01")
-    const err = t.throws(() =>
-      verifyTdxBase64(quoteB64, { date: late, crls: [] }),
+    const err = await t.throwsAsync(async () =>
+      await verifyTdxBase64(quoteB64, { date: late, crls: [] }),
     )
     t.truthy(err)
     t.regex(err!.message, /expired cert chain, or not yet valid/i)
@@ -839,7 +839,7 @@ test.serial("Reject a TDX quote with unsupported version", async (t) => {
   const mutated = Buffer.from(original)
   // header.version at offset 0 (UInt16LE)
   mutated.writeUInt16LE(6, 0)
-  const err = t.throws(() => verifyTdx(mutated, { date: BASE_TIME, crls: [] }))
+  const err = await t.throwsAsync(async () => await verifyTdx(mutated, { date: BASE_TIME, crls: [] }))
   t.truthy(err)
   t.regex(err!.message, /Unsupported quote version/i)
 })


### PR DESCRIPTION
Migrate `qvl/` package to use `@peculiar/webcrypto` and `@peculiar/x509` for browser and Node.js compatibility.

This migration involved replacing Node.js `crypto` module APIs with `@peculiar/webcrypto` and `@peculiar/x509` to ensure compatibility across both Node.js and browser environments. All cryptographic operations were converted to be asynchronous, and adjustments were made for differences in certificate property names and ECDSA signature formats expected by the new libraries. Corresponding tests were updated to reflect these asynchronous changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8dec712-e822-4294-a6fa-cf0cb71d08ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a8dec712-e822-4294-a6fa-cf0cb71d08ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

