### PR TITLE
Make qvl package browser and Node.js compatible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ra-https",
       "version": "0.0.0",
       "dependencies": {
+        "@peculiar/webcrypto": "^1.5.0",
         "@peculiar/x509": "^1.14.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
@@ -1334,6 +1335,34 @@
         "@peculiar/asn1-x509": "^2.5.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.5.0.tgz",
+      "integrity": "sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2",
+        "webcrypto-core": "^1.8.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
       }
     },
     "node_modules/@peculiar/x509": {
@@ -6394,6 +6423,19 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webcrypto-core": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.1.tgz",
+      "integrity": "sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.7.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "ava"
   },
   "dependencies": {
+    "@peculiar/webcrypto": "^1.5.0",
     "@peculiar/x509": "^1.14.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",

--- a/qvl/index.ts
+++ b/qvl/index.ts
@@ -5,3 +5,21 @@ export * from "./verifyTdx.js"
 export * from "./verifySgx.js"
 export type * from "./verifyTdx.js"
 export type * from "./verifySgx.js"
+import { cryptoProvider } from "@peculiar/x509"
+import { Crypto } from "@peculiar/webcrypto"
+
+// Initialize WebCrypto provider for @peculiar/x509 in Node.js and browsers
+try {
+  const anyGlobal = globalThis as any
+  const hasSubtle = !!(anyGlobal.crypto && anyGlobal.crypto.subtle)
+  if (!hasSubtle) {
+    const webcrypto = new Crypto()
+    ;(anyGlobal as any).crypto = webcrypto as unknown as Crypto
+    cryptoProvider.set(webcrypto as unknown as Crypto)
+  } else {
+    // Use existing global crypto (browser/Node >=19), but ensure x509 uses it
+    cryptoProvider.set(anyGlobal.crypto as Crypto)
+  }
+} catch {
+  // Best-effort init; consumers can call set again if they replace crypto
+}


### PR DESCRIPTION
Initialize WebCrypto provider for `@peculiar/x509` to enable the `qvl` package to work in both Node.js and browser environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-f94f315f-f65d-4a6a-95c5-957190ad4f12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f94f315f-f65d-4a6a-95c5-957190ad4f12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

