### PR TITLE
Simulate browser for TDX verification test

### DIFF
--- a/qvl/verifyTdx.ts
+++ b/qvl/verifyTdx.ts
@@ -7,10 +7,9 @@ import {
   cryptoProvider,
 } from "@peculiar/x509"
 
-const webCrypto =
-  globalThis.crypto && globalThis.crypto.subtle
-    ? globalThis.crypto
-    : new Crypto()
+// Set up crypto provider for browser compatibility
+// Use @peculiar/webcrypto for better browser compatibility
+const webCrypto = new Crypto()
 cryptoProvider.set(webCrypto as any)
 
 import {


### PR DESCRIPTION
Add a browser environment test and fix TDX verification by explicitly setting the crypto provider for X509 certificate processing.

The `verifyTdx` function previously relied on `globalThis.crypto` which could be inconsistent or improperly polyfilled in browser-like environments, causing X509 certificate chain verification to fail. By explicitly initializing and setting `@peculiar/webcrypto` as the crypto provider, we ensure a consistent and compatible Web Crypto API implementation, resolving the "invalid cert chain" error in browser contexts.

---
<a href="https://cursor.com/background-agent?bcId=bc-cb1614ed-6302-4d93-8a2e-1f86916f1141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cb1614ed-6302-4d93-8a2e-1f86916f1141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

