### PR TITLE
Refactor qvl directory from binary-parser to restructure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@peculiar/webcrypto": "^1.5.0",
         "@scure/base": "^2.0.0",
         "asn1js": "^3.0.5",
-        "binary-parser": "^2.2.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
@@ -21,6 +20,7 @@
         "pkijs": "^3.0.18",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "restructure": "^3.0.2",
         "uint8array-extras": "^1.5.0",
         "webcrypto-liner": "^1.4.3",
         "ws": "^8.18.3"
@@ -2371,15 +2371,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/binary-parser": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/binary-parser/-/binary-parser-2.2.1.tgz",
-      "integrity": "sha512-5ATpz/uPDgq5GgEDxTB4ouXCde7q2lqAQlSdBRQVl/AJnxmQmhIfyxJx+0MGu//D5rHQifkfGbWWlaysG0o9NA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/bindings": {
       "version": "1.5.0",
@@ -6378,6 +6369,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@peculiar/webcrypto": "^1.5.0",
     "@scure/base": "^2.0.0",
     "asn1js": "^3.0.5",
-    "binary-parser": "^2.2.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
@@ -27,6 +26,7 @@
     "pkijs": "^3.0.18",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "restructure": "^3.0.2",
     "uint8array-extras": "^1.5.0",
     "webcrypto-liner": "^1.4.3",
     "ws": "^8.18.3"

--- a/qvl/structs.ts
+++ b/qvl/structs.ts
@@ -1,127 +1,180 @@
-import { Parser } from "binary-parser"
+import * as r from "restructure"
 import { base64 as scureBase64 } from "@scure/base"
 
-export type Parsed<T extends Parser<any>> =
-  T extends Parser<infer R> ? R : never
+export type QuoteHeaderType = {
+  version: number
+  att_key_type: number
+  tee_type: number
+  qe_svn: number
+  pce_svn: number
+  qe_vendor_id: Uint8Array
+  user_data: Uint8Array
+}
 
-export const QuoteHeader = new Parser()
-  .uint16le("version")
-  .uint16le("att_key_type")
-  .uint32le("tee_type")
-  .uint16le("qe_svn")
-  .uint16le("pce_svn")
-  .buffer("qe_vendor_id", { length: 16 })
-  .buffer("user_data", { length: 20 })
+export const QuoteHeader = new r.Struct({
+  version: r.uint16le,
+  att_key_type: r.uint16le,
+  tee_type: r.uint32le,
+  qe_svn: r.uint16le,
+  pce_svn: r.uint16le,
+  qe_vendor_id: new r.Buffer(16),
+  user_data: new r.Buffer(20),
+})
 
-export const SgxReportBody = new Parser()
-  .buffer("cpu_svn", { length: 16 })
-  .uint32le("misc_select")
-  .buffer("reserved1", { length: 28 })
-  .buffer("attributes", { length: 16 })
-  .buffer("mr_enclave", { length: 32 })
-  .buffer("reserved2", { length: 32 })
-  .buffer("mr_signer", { length: 32 })
-  .buffer("reserved3", { length: 96 })
-  .uint16le("isv_prod_id")
-  .uint16le("isv_svn")
-  .buffer("reserved4", { length: 60 })
-  .buffer("report_data", { length: 64 })
+export type SgxReportBodyType = {
+  cpu_svn: Uint8Array
+  misc_select: number
+  reserved1: Uint8Array
+  attributes: Uint8Array
+  mr_enclave: Uint8Array
+  reserved2: Uint8Array
+  mr_signer: Uint8Array
+  reserved3: Uint8Array
+  isv_prod_id: number
+  isv_svn: number
+  reserved4: Uint8Array
+  report_data: Uint8Array
+}
 
-export const TdxQuoteBody_1_0 = new Parser()
-  .buffer("tee_tcb_svn", { length: 16 })
-  .buffer("mr_seam", { length: 48 })
-  .buffer("mr_seam_signer", { length: 48 })
-  .uint32le("seam_svn")
-  .uint32le("reserved0")
-  .buffer("td_attributes", { length: 8 })
-  .buffer("xfam", { length: 8 })
-  .buffer("mr_td", { length: 48 })
-  .buffer("mr_config_id", { length: 48 })
-  .buffer("mr_owner", { length: 48 })
-  .buffer("mr_owner_config", { length: 48 })
-  .buffer("rtmr0", { length: 48 })
-  .buffer("rtmr1", { length: 48 })
-  .buffer("rtmr2", { length: 48 })
-  .buffer("rtmr3", { length: 48 })
-  .buffer("report_data", { length: 64 })
+export const SgxReportBody = new r.Struct({
+  cpu_svn: new r.Buffer(16),
+  misc_select: r.uint32le,
+  reserved1: new r.Buffer(28),
+  attributes: new r.Buffer(16),
+  mr_enclave: new r.Buffer(32),
+  reserved2: new r.Buffer(32),
+  mr_signer: new r.Buffer(32),
+  reserved3: new r.Buffer(96),
+  isv_prod_id: r.uint16le,
+  isv_svn: r.uint16le,
+  reserved4: new r.Buffer(60),
+  report_data: new r.Buffer(64),
+})
 
-export const TdxQuoteBody_1_5 = new Parser()
-  .buffer("tee_tcb_svn", { length: 16 })
-  .buffer("mr_seam", { length: 48 })
-  .buffer("mr_seam_signer", { length: 48 })
-  .uint32le("seam_svn")
-  .uint32le("reserved0")
-  .buffer("td_attributes", { length: 8 })
-  .buffer("xfam", { length: 8 })
-  .buffer("mr_td", { length: 48 })
-  .buffer("mr_config_id", { length: 48 })
-  .buffer("mr_owner", { length: 48 })
-  .buffer("mr_owner_config", { length: 48 })
-  .buffer("rtmr0", { length: 48 })
-  .buffer("rtmr1", { length: 48 })
-  .buffer("rtmr2", { length: 48 })
-  .buffer("rtmr3", { length: 48 })
-  .buffer("report_data", { length: 64 })
-  .buffer("tee_tcb_svn_2", { length: 16 })
-  .buffer("mrservictd", { length: 48 })
+export type TdxQuoteBody10Type = {
+  tee_tcb_svn: Uint8Array
+  mr_seam: Uint8Array
+  mr_seam_signer: Uint8Array
+  seam_svn: number
+  reserved0: number
+  td_attributes: Uint8Array
+  xfam: Uint8Array
+  mr_td: Uint8Array
+  mr_config_id: Uint8Array
+  mr_owner: Uint8Array
+  mr_owner_config: Uint8Array
+  rtmr0: Uint8Array
+  rtmr1: Uint8Array
+  rtmr2: Uint8Array
+  rtmr3: Uint8Array
+  report_data: Uint8Array
+}
 
-export const SgxQuote = new Parser()
-  .nest("header", { type: QuoteHeader })
-  .nest("body", { type: SgxReportBody })
-  .uint32le("sig_data_len")
-  .buffer("sig_data", { readUntil: "eof" })
+export const TdxQuoteBody_1_0 = new r.Struct({
+  tee_tcb_svn: new r.Buffer(16),
+  mr_seam: new r.Buffer(48),
+  mr_seam_signer: new r.Buffer(48),
+  seam_svn: r.uint32le,
+  reserved0: r.uint32le,
+  td_attributes: new r.Buffer(8),
+  xfam: new r.Buffer(8),
+  mr_td: new r.Buffer(48),
+  mr_config_id: new r.Buffer(48),
+  mr_owner: new r.Buffer(48),
+  mr_owner_config: new r.Buffer(48),
+  rtmr0: new r.Buffer(48),
+  rtmr1: new r.Buffer(48),
+  rtmr2: new r.Buffer(48),
+  rtmr3: new r.Buffer(48),
+  report_data: new r.Buffer(64),
+})
 
-export const SgxTail = new Parser()
-  .uint16le("cert_data_type")
-  .uint32le("cert_data_len")
-  .buffer("cert_data", { readUntil: "eof" })
+export type TdxQuoteBody15Type = TdxQuoteBody10Type & {
+  tee_tcb_svn_2: Uint8Array
+  mrservictd: Uint8Array
+}
 
-export const TdxQuoteV4 = new Parser()
-  .nest("header", { type: QuoteHeader })
-  .nest("body", { type: TdxQuoteBody_1_0 })
-  .uint32le("sig_data_len")
-  .buffer("sig_data", { readUntil: "eof" })
+export const TdxQuoteBody_1_5 = new r.Struct({
+  tee_tcb_svn: new r.Buffer(16),
+  mr_seam: new r.Buffer(48),
+  mr_seam_signer: new r.Buffer(48),
+  seam_svn: r.uint32le,
+  reserved0: r.uint32le,
+  td_attributes: new r.Buffer(8),
+  xfam: new r.Buffer(8),
+  mr_td: new r.Buffer(48),
+  mr_config_id: new r.Buffer(48),
+  mr_owner: new r.Buffer(48),
+  mr_owner_config: new r.Buffer(48),
+  rtmr0: new r.Buffer(48),
+  rtmr1: new r.Buffer(48),
+  rtmr2: new r.Buffer(48),
+  rtmr3: new r.Buffer(48),
+  report_data: new r.Buffer(64),
+  tee_tcb_svn_2: new r.Buffer(16),
+  mrservictd: new r.Buffer(48),
+})
 
-export const TdxQuoteV5Descriptor = new Parser()
-  .nest("header", { type: QuoteHeader })
-  .uint16le("body_type")
-  .uint32le("body_size")
-  .buffer("extra", { readUntil: "eof" })
+function readUInt16LE(buf: Uint8Array, offset: number): number {
+  return new DataView(buf.buffer, buf.byteOffset + offset, 2).getUint16(0, true)
+}
 
-export const TdxQuoteV5SigDescriptor = new Parser()
-  .uint32le("sig_data_len")
-  .buffer("sig_data", { readUntil: "eof" })
+function readUInt32LE(buf: Uint8Array, offset: number): number {
+  return new DataView(buf.buffer, buf.byteOffset + offset, 4).getUint32(0, true)
+}
 
 /**
  * SGX signatures contain a fixed-length ECDSA signature section, and
  * a variable-length cert_data tail.
  */
 export function parseSgxSignature(quote: Uint8Array) {
-  const { sig_data } = SgxQuote.parse(quote)
+  const headerLen = QuoteHeader.size()
+  const bodyLen = SgxReportBody.size()
+  const signedLen = headerLen + bodyLen
+  const sigLen = readUInt32LE(quote, signedLen)
+  const sigStart = signedLen + 4
+  const sig_data = quote.subarray(sigStart, sigStart + sigLen)
 
-  const EcdsaSignatureFixed = new Parser()
-    .buffer("signature", { length: 64 })
-    .buffer("attestation_public_key", { length: 64 })
-    .buffer("qe_report", { length: 384 })
-    .buffer("qe_report_signature", { length: 64 })
-    .uint16le("qe_auth_data_len")
-    .buffer("extra", { readUntil: "eof" })
-  const fixed = EcdsaSignatureFixed.parse(sig_data)
+  const EcdsaSignatureFixed = new r.Struct({
+    signature: new r.Buffer(64),
+    attestation_public_key: new r.Buffer(64),
+    qe_report: new r.Buffer(384),
+    qe_report_signature: new r.Buffer(64),
+    qe_auth_data_len: r.uint16le,
+  })
 
-  const tail = fixed.extra.subarray(fixed.qe_auth_data_len)
-  const { cert_data_type, cert_data_len, cert_data } = SgxTail.parse(tail)
+  const fixed = EcdsaSignatureFixed.fromBuffer(sig_data)
+  let offset = EcdsaSignatureFixed.size()
+
+  const qe_auth_data = sig_data.subarray(
+    offset,
+    offset + fixed.qe_auth_data_len,
+  )
+  offset += fixed.qe_auth_data_len
+
+  const Tail = new r.Struct({
+    cert_data_type: r.uint16le,
+    cert_data_len: r.uint32le,
+  })
+
+  const tailHeader = Tail.fromBuffer(sig_data.subarray(offset))
+  const tailHeaderSize = Tail.size()
+  const cert_data = sig_data.subarray(
+    offset + tailHeaderSize,
+    offset + tailHeaderSize + tailHeader.cert_data_len,
+  )
 
   return {
     ecdsa_signature: fixed.signature,
     attestation_public_key: fixed.attestation_public_key,
     qe_report: fixed.qe_report,
-    qe_report_present: !!fixed.qe_report,
+    qe_report_present: fixed.qe_report.length === 384,
     qe_report_signature: fixed.qe_report_signature,
     qe_auth_data_len: fixed.qe_auth_data_len,
-    qe_auth_data: fixed.extra.subarray(0, fixed.qe_auth_data_len),
-    cert_data_type,
-    cert_data_len,
-    cert_data: cert_data.subarray(0, cert_data_len),
+    qe_auth_data,
+    cert_data_type: tailHeader.cert_data_type,
+    cert_data_len: tailHeader.cert_data_len,
+    cert_data,
   }
 }
 
@@ -133,23 +186,35 @@ export function parseSgxSignature(quote: Uint8Array) {
 export function parseTdxSignature(quote: Uint8Array, v5?: boolean) {
   let sig_data
   if (!v5) {
-    sig_data = TdxQuoteV4.parse(quote).sig_data
+    const headerLen = QuoteHeader.size()
+    const bodyLen = TdxQuoteBody_1_0.size()
+    const signedLen = headerLen + bodyLen
+    const sigLen = readUInt32LE(quote, signedLen)
+    const sigStart = signedLen + 4
+    sig_data = quote.subarray(sigStart, sigStart + sigLen)
   } else {
-    const { body_size, extra } = TdxQuoteV5Descriptor.parse(quote)
-    sig_data = TdxQuoteV5SigDescriptor.parse(extra.subarray(body_size)).sig_data
+    const headerLen = QuoteHeader.size()
+    const descOffset = headerLen
+    // body_type is at descOffset, but we only need body_size here
+    const body_size = readUInt32LE(quote, descOffset + 2)
+    const sigDescStart = descOffset + 2 + 4 + body_size
+    const sigLen = readUInt32LE(quote, sigDescStart)
+    const sigStart = sigDescStart + 4
+    sig_data = quote.subarray(sigStart, sigStart + sigLen)
   }
 
-  const EcdsaSigFixed = new Parser()
-    .buffer("signature", { length: 64 })
-    .buffer("attestation_public_key", { length: 64 })
-    .uint16le("cert_type")
-    .uint32le("cert_size")
-    .buffer("qe_report", { length: 384 })
-    .buffer("qe_report_signature", { length: 64 })
-    .uint16le("qe_auth_data_len")
+  const EcdsaSigFixed = new r.Struct({
+    signature: new r.Buffer(64),
+    attestation_public_key: new r.Buffer(64),
+    cert_type: r.uint16le,
+    cert_size: r.uint32le,
+    qe_report: new r.Buffer(384),
+    qe_report_signature: new r.Buffer(64),
+    qe_auth_data_len: r.uint16le,
+  })
 
-  const fixed = EcdsaSigFixed.parse(sig_data)
-  let offset = EcdsaSigFixed.sizeOf()
+  const fixed = EcdsaSigFixed.fromBuffer(sig_data)
+  let offset = EcdsaSigFixed.size()
 
   const qe_auth_data = sig_data.subarray(
     offset,
@@ -157,14 +222,17 @@ export function parseTdxSignature(quote: Uint8Array, v5?: boolean) {
   )
   offset += fixed.qe_auth_data_len
 
-  const Tail = new Parser().uint16le("cert_data_type").uint32le("cert_data_len")
+  const Tail = new r.Struct({
+    cert_data_type: r.uint16le,
+    cert_data_len: r.uint32le,
+  })
 
-  const { cert_data_type, cert_data_len } = Tail.parse(
-    sig_data.subarray(offset, offset + Tail.sizeOf()),
+  const tailHeader = Tail.fromBuffer(sig_data.subarray(offset))
+  const tailHeaderSize = Tail.size()
+  const cert_data = sig_data.subarray(
+    offset + tailHeaderSize,
+    offset + tailHeaderSize + tailHeader.cert_data_len,
   )
-  offset += Tail.sizeOf()
-
-  const cert_data = sig_data.subarray(offset, offset + cert_data_len)
 
   return {
     ecdsa_signature: fixed.signature,
@@ -174,8 +242,8 @@ export function parseTdxSignature(quote: Uint8Array, v5?: boolean) {
     qe_report_signature: fixed.qe_report_signature,
     qe_auth_data_len: fixed.qe_auth_data_len,
     qe_auth_data,
-    cert_data_type,
-    cert_data_len,
+    cert_data_type: tailHeader.cert_data_type,
+    cert_data_len: tailHeader.cert_data_len,
     cert_data,
   }
 }
@@ -187,15 +255,15 @@ export type TdxSignature = ReturnType<typeof parseTdxSignature>
  * Compute the signed region of an SGX quote: header || body (excludes sig length and sig_data)
  */
 export function getSgxSignedRegion(quoteBytes: Uint8Array): Uint8Array {
-  return quoteBytes.subarray(0, QuoteHeader.sizeOf() + SgxReportBody.sizeOf())
+  return quoteBytes.subarray(0, QuoteHeader.size() + SgxReportBody.size())
 }
 
 /**
  * Compute the signed region of a TDX 1.0 quote: header || body (excludes sig length and sig_data)
  */
 export function getTdx10SignedRegion(quoteBytes: Uint8Array): Uint8Array {
-  const headerLen = QuoteHeader.sizeOf()
-  const bodyLen = TdxQuoteBody_1_0.sizeOf()
+  const headerLen = QuoteHeader.size()
+  const bodyLen = TdxQuoteBody_1_0.size()
   return quoteBytes.subarray(0, headerLen + bodyLen)
 }
 
@@ -203,8 +271,8 @@ export function getTdx10SignedRegion(quoteBytes: Uint8Array): Uint8Array {
  * Compute the signed region of a TDX 1.5 quote: header || body_descriptor || body
  */
 export function getTdx15SignedRegion(quoteBytes: Uint8Array): Uint8Array {
-  const { body_size } = TdxQuoteV5Descriptor.parse(quoteBytes)
-  const headerLen = QuoteHeader.sizeOf()
+  const headerLen = QuoteHeader.size()
+  const body_size = readUInt32LE(quoteBytes, headerLen + 2)
   const totalLen = headerLen + 2 + 4 + body_size
   return quoteBytes.subarray(0, totalLen)
 }
@@ -212,31 +280,37 @@ export function getTdx15SignedRegion(quoteBytes: Uint8Array): Uint8Array {
 /**
  * Parse a TDX 1.0 or 1.5 quote as header, body, and signature.
  */
-export type QuoteHeaderType = Parsed<typeof QuoteHeader>
-export type TdxQuoteBody10Type = Parsed<typeof TdxQuoteBody_1_0>
-export type TdxQuoteBody15Type = Parsed<typeof TdxQuoteBody_1_5>
+// types are exported by declaration above
 
 export function parseTdxQuote(quote: Uint8Array): {
   header: QuoteHeaderType
   body: TdxQuoteBody10Type | TdxQuoteBody15Type
   signature: TdxSignature
 } {
-  const header = QuoteHeader.parse(quote)
+  const header = QuoteHeader.fromBuffer(quote)
   if (header.version === 4) {
-    const { body } = TdxQuoteV4.parse(quote)
+    const body = TdxQuoteBody_1_0.fromBuffer(
+      quote.subarray(QuoteHeader.size()),
+    )
     const signature = parseTdxSignature(quote)
 
     return { header, body, signature }
   } else if (header.version === 5) {
-    const { body_type, body_size, extra } = TdxQuoteV5Descriptor.parse(quote)
+    const headerLen = QuoteHeader.size()
+    const body_type = readUInt16LE(quote, headerLen)
+    const body_size = readUInt32LE(quote, headerLen + 2)
 
     let body: TdxQuoteBody10Type | TdxQuoteBody15Type
     if (body_type === 1) {
       throw new Error("parseQuote: unexpected body_type = 1")
     } else if (body_type === 2) {
-      body = TdxQuoteBody_1_0.parse(extra.subarray(0, body_size))
+      body = TdxQuoteBody_1_0.fromBuffer(
+        quote.subarray(headerLen + 2 + 4, headerLen + 2 + 4 + body_size),
+      )
     } else if (body_type === 3) {
-      body = TdxQuoteBody_1_5.parse(extra.subarray(0, body_size))
+      body = TdxQuoteBody_1_5.fromBuffer(
+        quote.subarray(headerLen + 2 + 4, headerLen + 2 + 4 + body_size),
+      )
     } else {
       throw new Error("parseQuote: unexpected body_type")
     }
@@ -259,15 +333,15 @@ export function parseTdxQuoteBase64(quote: string) {
  */
 export function parseSgxQuote(quote: Uint8Array): {
   header: QuoteHeaderType
-  body: Parsed<typeof SgxReportBody>
+  body: SgxReportBodyType
   signature: SgxSignature
 } {
-  const header = QuoteHeader.parse(quote)
+  const header = QuoteHeader.fromBuffer(quote)
   if (header.version !== 3) {
     throw new Error("parseQuote: Unsupported SGX quote version")
   }
 
-  const { body } = SgxQuote.parse(quote)
+  const body = SgxReportBody.fromBuffer(quote.subarray(QuoteHeader.size()))
   const signature = parseSgxSignature(quote)
 
   return { header, body, signature }

--- a/types/binary-parser/index.d.ts
+++ b/types/binary-parser/index.d.ts
@@ -1,18 +1,2 @@
-declare module "binary-parser" {
-  export class Parser<TParsed = any> {
-    constructor()
-    uint16le(this: this, name: string): this
-    uint32le(this: this, name: string): this
-    buffer(
-      this: this,
-      name: string,
-      opts: {
-        length?: number
-        readUntil?: "eof" | ((item: any, buffer: Buffer) => boolean)
-      },
-    ): this
-    nest(this: this, name: string, opts: { type: Parser<any> }): this
-    parse(buffer: Buffer | Uint8Array): TParsed
-    sizeOf(): number
-  }
-}
+// Removed: binary-parser migration complete; keeping empty module to avoid stray imports.
+declare module "binary-parser" {}

--- a/types/restructure/index.d.ts
+++ b/types/restructure/index.d.ts
@@ -1,0 +1,71 @@
+declare module "restructure" {
+  export class Base {
+    fromBuffer<T = any>(buffer: Uint8Array): T
+    toBuffer(value: any): Uint8Array
+    size(value?: any): number
+  }
+
+  export class Struct<T = any> extends Base {
+    constructor(fields?: Record<string, any>)
+  }
+
+  export class Buffer extends Base {
+    constructor(length: number | string | ((parent: any) => number))
+  }
+
+  export class String extends Base {
+    constructor(length: number | string | ((parent: any) => number) | null, encoding?: string)
+  }
+
+  export class Array<T = any> extends Base {
+    constructor(type: any, length: number | string | ((parent: any) => number), mode?: "bytes")
+  }
+
+  export class VersionedStruct<T = any> extends Base {
+    constructor(versionType: any, versions: Record<string | number, any>)
+  }
+
+  export class Optional<T = any> extends Base {
+    constructor(type: any, condition: boolean | (() => boolean))
+  }
+
+  export class Enum<T = any> extends Base {
+    constructor(type: any, values: T[])
+  }
+
+  export class Bitfield<T = any> extends Base {
+    constructor(type: any, fields: string[])
+  }
+
+  export const uint8: any
+  export const uint16: any
+  export const uint16le: any
+  export const uint24: any
+  export const uint24le: any
+  export const uint32: any
+  export const uint32le: any
+  export const int8: any
+  export const int16: any
+  export const int16le: any
+  export const int24: any
+  export const int24le: any
+  export const int32: any
+  export const int32le: any
+  export const float: any
+  export const floatle: any
+  export const double: any
+  export const doublele: any
+  export const fixed16: any
+  export const fixed16le: any
+  export const fixed32: any
+  export const fixed32le: any
+
+  export const EncodeStream: any
+  export const DecodeStream: any
+  export const Reserved: any
+  export const Pointer: any
+  export const LazyArray: any
+  export const Boolean: any
+  export * from "restructure"
+}
+


### PR DESCRIPTION
Replace `binary-parser` with `restructure` in `qvl/structs.ts` to migrate the parsing library.

This involved updating dependencies, refactoring parser definitions to `restructure.Struct`, and manually handling variable-length sections (e.g., signature and certificate data) due to API differences. Type definitions for both libraries were also adjusted.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a9a7718-1a1f-4582-a031-6aabdf06ce8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6a9a7718-1a1f-4582-a031-6aabdf06ce8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

