### PR TITLE
Organize and migrate qvl tests

### DIFF
--- a/test/qvl-helpers.ts
+++ b/test/qvl-helpers.ts
@@ -1,0 +1,164 @@
+import fs from "node:fs"
+import {
+  QV_X509Certificate,
+  computeCertSha256Hex,
+  extractPemCertificates,
+  getTdx10SignedRegion,
+  parseTdxQuote,
+  parseTdxQuoteBase64,
+  verifyPCKChain,
+} from "../qvl"
+
+export const BASE_TIME = Date.parse("2025-09-01")
+
+export function pemToDer(pem: string): Buffer {
+  const b64 = pem
+    .replace(/-----BEGIN CERTIFICATE-----/g, "")
+    .replace(/-----END CERTIFICATE-----/g, "")
+    .replace(/\s+/g, "")
+  return Buffer.from(b64, "base64")
+}
+
+export function derToPem(der: Buffer): string {
+  const b64 = der.toString("base64")
+  const lines = b64.match(/.{1,64}/g) || []
+  return `-----BEGIN CERTIFICATE-----\n${lines.join("\n")}\n-----END CERTIFICATE-----\n`
+}
+
+export function tamperPemSignature(pem: string): string {
+  const der = Buffer.from(pemToDer(pem))
+  der[der.length - 1] ^= 0x01
+  return derToPem(der)
+}
+
+export function buildCRLWithSerials(serialsUpperHex: string[]): Buffer {
+  const encodeLen = (len: number) => {
+    if (len < 0x80) return Buffer.from([len])
+    const bytes: number[] = []
+    let v = len
+    while (v > 0) {
+      bytes.unshift(v & 0xff)
+      v >>= 8
+    }
+    return Buffer.from([0x80 | bytes.length, ...bytes])
+  }
+  const tlv = (tag: number, value: Buffer) =>
+    Buffer.concat([Buffer.from([tag]), encodeLen(value.length), value])
+
+  const encodeIntegerHex = (hex: string) => {
+    let v = Buffer.from(hex.replace(/[^0-9A-F]/g, ""), "hex")
+    if (v.length === 0) v = Buffer.from([0])
+    if (v[0] & 0x80) v = Buffer.concat([Buffer.from([0x00]), v])
+    return tlv(0x02, v)
+  }
+
+  const version = tlv(0x02, Buffer.from([0x01]))
+  const sigAlg = tlv(0x30, Buffer.alloc(0))
+  const issuer = tlv(0x30, Buffer.alloc(0))
+  const thisUpdate = tlv(0x17, Buffer.from("250101000000Z"))
+
+  const revokedEntries = serialsUpperHex.map((s) =>
+    tlv(0x30, encodeIntegerHex(s)),
+  )
+  const revokedSeq = tlv(0x30, Buffer.concat(revokedEntries))
+
+  const tbs = tlv(
+    0x30,
+    Buffer.concat([version, sigAlg, issuer, thisUpdate, revokedSeq]),
+  )
+  const outer = tlv(0x30, tbs)
+  return outer
+}
+
+export function rebuildQuoteWithCertData(
+  baseQuote: Buffer,
+  certData: Buffer,
+): Buffer {
+  const signedLen = getTdx10SignedRegion(baseQuote).length
+  const sigLen = baseQuote.readUInt32LE(signedLen)
+  const sigStart = signedLen + 4
+  const sigData = baseQuote.subarray(sigStart, sigStart + sigLen)
+
+  const FIXED_LEN = 64 + 64 + 6 + 384 + 64 + 2 // ECDSA fixed portion
+  const qeAuthLen = sigData.readUInt16LE(64 + 64 + 6 + 384 + 64)
+  const fixedPlusAuth = sigData.subarray(0, FIXED_LEN + qeAuthLen)
+
+  const tail = Buffer.alloc(2 + 4)
+  tail.writeUInt16LE(5, 0) // cert_data_type = 5 (PCK)
+  tail.writeUInt32LE(certData.length, 2)
+
+  const newSigData = Buffer.concat([fixedPlusAuth, tail, certData])
+  const newSigLen = Buffer.alloc(4)
+  newSigLen.writeUInt32LE(newSigData.length, 0)
+
+  const prefix = baseQuote.subarray(0, signedLen)
+  return Buffer.concat([prefix, newSigLen, newSigData])
+}
+
+export function getGcpQuoteBase64(): string {
+  const data = JSON.parse(
+    fs.readFileSync("test/sample/tdx-v4-gcp.json", "utf-8"),
+  )
+  return data.tdx.quote as string
+}
+
+export async function getGcpCertPems(): Promise<{
+  leaf: string
+  intermediate: string
+  root: string
+  all: string[]
+}> {
+  const quoteB64 = getGcpQuoteBase64()
+  const { signature } = parseTdxQuoteBase64(quoteB64)
+  const pems = extractPemCertificates(signature.cert_data)
+  const { chain } = await verifyPCKChain(pems, null)
+  const hashToPem = new Map<string, string>()
+  for (const pem of pems) {
+    const h = await computeCertSha256Hex(new QV_X509Certificate(pem))
+    hashToPem.set(h, pem)
+  }
+  const leafPem = hashToPem.get(await computeCertSha256Hex(chain[0]))!
+  const intermediatePem = hashToPem.get(
+    await computeCertSha256Hex(chain[1]),
+  )!
+  const rootPem = hashToPem.get(await computeCertSha256Hex(chain[2]))!
+  return {
+    leaf: leafPem,
+    intermediate: intermediatePem,
+    root: rootPem,
+    all: pems,
+  }
+}
+
+export function getV5QuoteBuffer(): Buffer {
+  return fs.readFileSync("test/sample/tdx-v5-trustee.dat")
+}
+
+export async function getV5CertPems(): Promise<{
+  leaf: string
+  intermediate: string
+  root: string
+  all: string[]
+}> {
+  const quote = getV5QuoteBuffer()
+  const { signature } = parseTdxQuote(quote)
+  const pems = extractPemCertificates(signature.cert_data)
+  const { chain } = await verifyPCKChain(pems, null)
+  const hashToPem = new Map<string, string>()
+  for (const pem of pems) {
+    const h = await computeCertSha256Hex(new QV_X509Certificate(pem))
+    hashToPem.set(h, pem)
+  }
+  const leafPem = hashToPem.get(await computeCertSha256Hex(chain[0]))!
+  const intermediatePem = hashToPem.get(
+    await computeCertSha256Hex(chain[1]),
+  )!
+  const rootPem = hashToPem.get(await computeCertSha256Hex(chain[2]))!
+  return {
+    leaf: leafPem,
+    intermediate: intermediatePem,
+    root: rootPem,
+    all: pems,
+  }
+}
+

--- a/test/qvl-sgx.test.ts
+++ b/test/qvl-sgx.test.ts
@@ -1,0 +1,123 @@
+import test from "ava"
+import fs from "node:fs"
+import { QV_X509Certificate, hex, parseSgxQuote, verifySgx, extractPemCertificates } from "../qvl"
+import { BASE_TIME } from "./qvl-helpers"
+
+test.serial("Verify an SGX quote from Intel, no quote signature", async (t) => {
+  const quote = fs.readFileSync("test/sample/sgx/quote.dat")
+  const { header, body, signature } = parseSgxQuote(quote)
+
+  const expectedMrEnclave =
+    "0000000000000000000000000000000000000000000000000000000000000000"
+  const expectedReportData =
+    "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+  t.is(header.version, 3)
+  t.is(header.tee_type, 0)
+  t.is(hex(body.mr_enclave), expectedMrEnclave)
+  t.is(hex(body.report_data), expectedReportData)
+  t.deepEqual(body.mr_signer, Buffer.alloc(32))
+  t.deepEqual(body.attributes, Buffer.alloc(16))
+  t.deepEqual(body.cpu_svn, Buffer.alloc(16))
+
+  t.is(
+    hex(signature.ecdsa_signature),
+    "021a1375acdfc4520ade2f984b051e59a54e2892b24d3aa98e543b7b49eef2a375a7b5bafd1f1972e604fd799d4a01e2e422a52558768606daade2b17a6313ee",
+  )
+
+  // Intel sample is missing certdata, reconstruct it from provided PEM files instead
+  const root = extractPemCertificates(
+    fs.readFileSync("test/sample/sgx/trustedRootCaCert.pem"),
+  )
+  const pckChain = extractPemCertificates(
+    fs.readFileSync("test/sample/sgx/pckSignChain.pem"),
+  )
+  const pckCert = extractPemCertificates(
+    fs.readFileSync("test/sample/sgx/pckCert.pem"),
+  )
+  const certdata = [...root, ...pckChain, ...pckCert]
+
+  // Use provided certificate revocation lists
+  const crls = [
+    fs.readFileSync("test/sample/sgx/rootCaCrl.der"),
+    fs.readFileSync("test/sample/sgx/intermediateCaCrl.der"),
+  ]
+
+  t.true(
+    await verifySgx(quote, {
+      pinnedRootCerts: [new QV_X509Certificate(root[0])],
+      date: BASE_TIME,
+      crls,
+      extraCertdata: certdata,
+    }),
+  )
+})
+
+test.serial("Verify an SGX quote from Occlum", async (t) => {
+  const quote = fs.readFileSync("test/sample/sgx-occlum.dat")
+  const { header, body } = parseSgxQuote(quote)
+
+  const expectedMrEnclave =
+    "9c90fd81f6e9fe64b46b14f0623523a52d6a5678482988c408f6adffe6301e2c"
+  const expectedReportData =
+    "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+
+  t.is(header.version, 3)
+  t.is(header.tee_type, 0)
+  t.is(hex(body.mr_enclave), expectedMrEnclave)
+  t.is(hex(body.report_data), expectedReportData)
+
+  t.true(await verifySgx(quote, { date: BASE_TIME, crls: [] }))
+})
+
+test.serial("Verify an SGX quote from chinenyeokafor", async (t) => {
+  const quote = fs.readFileSync("test/sample/sgx-chinenyeokafor.dat")
+  const { header, body } = parseSgxQuote(quote)
+
+  const expectedMrEnclave =
+    "0696ab235b2d339e68a4303cb64cde005bb8cdf2448bed742ac8ea8339bd0cb7"
+  const expectedReportData =
+    "888d97435fd51947e5a8c71f73ba24d9abcf716a1ac05b495a54f9a6fb54609e0000000000000000000000000000000000000000000000000000000000000000"
+
+  t.is(header.version, 3)
+  t.is(header.tee_type, 0)
+  t.is(hex(body.mr_enclave), expectedMrEnclave)
+  t.is(hex(body.report_data), expectedReportData)
+
+  t.true(await verifySgx(quote, { date: BASE_TIME, crls: [] }))
+})
+
+test.serial("Verify an SGX quote from TLSN, quote9", async (t) => {
+  const quote = fs.readFileSync("test/sample/sgx-tlsn-quote9.dat")
+  const { header, body } = parseSgxQuote(quote)
+
+  const expectedMrEnclave =
+    "50a6a608c1972408f94379f83a7af2ea55b31095f131efe93af74f5968a44f29"
+  const expectedReportData =
+    "03351d6944f43d3041a075bddf540d2b91595979ef67fee8c9e6f1c3a5ff6e9e7300000000000000000000000000000000000000000000000000000000000000"
+
+  t.is(header.version, 3)
+  t.is(header.tee_type, 0)
+  t.is(hex(body.mr_enclave), expectedMrEnclave)
+  t.is(hex(body.report_data), expectedReportData)
+
+  t.true(await verifySgx(quote, { date: BASE_TIME, crls: [] }))
+})
+
+test.serial("Verify an SGX quote from TLSN, quote_dev", async (t) => {
+  const quote = fs.readFileSync("test/sample/sgx-tlsn-quotedev.dat")
+  const { header, body } = parseSgxQuote(quote)
+
+  const expectedMrEnclave =
+    "db5e55d3190d92512e4eae09d697b4b5fe30c2212e1ad6db5681379608c46204"
+  const expectedReportData =
+    "030eba01d248d2c2fb4f39fc8f2daaf2392560100989eb022dc6570e87a011b29c00000000000000000000000000000000000000000000000000000000000000"
+
+  t.is(header.version, 3)
+  t.is(header.tee_type, 0)
+  t.is(hex(body.mr_enclave), expectedMrEnclave)
+  t.is(hex(body.report_data), expectedReportData)
+
+  t.true(await verifySgx(quote, { date: BASE_TIME, crls: [] }))
+})
+

--- a/test/qvl-tdxv5.test.ts
+++ b/test/qvl-tdxv5.test.ts
@@ -1,0 +1,249 @@
+import test from "ava"
+import fs from "node:fs"
+import {
+  parseTdxQuote,
+  hex,
+  verifyTdx,
+  getTdx10SignedRegion,
+  QV_X509Certificate,
+  normalizeSerialHex,
+} from "../qvl"
+import {
+  BASE_TIME,
+  tamperPemSignature,
+  buildCRLWithSerials,
+  rebuildQuoteWithCertData,
+  getV5QuoteBuffer,
+  getV5CertPems,
+} from "./qvl-helpers"
+
+test.serial("Verify a V5 TDX quote from Trustee", async (t) => {
+  const quote = fs.readFileSync("test/sample/tdx-v5-trustee.dat")
+  const { header, body } = parseTdxQuote(quote)
+
+  const expectedMRTD =
+    "dfba221b48a22af8511542ee796603f37382800840dcd978703909bf8e64d4c8a1e9de86e7c9638bfcba422f3886400a"
+  const expectedReportData =
+    "6d6ab13b046cff606ac0074be13981b07b6325dba10b5facc96febf551c0c3be2b75f92fe1f88f4bb996969ad0174b4b7a70261b7b85c844f4b33a4674fd049f"
+
+  t.is(header.version, 5)
+  t.is(header.tee_type, 129)
+  t.is(hex(body.mr_td), expectedMRTD)
+  t.is(hex(body.report_data), expectedReportData)
+  t.deepEqual(body.mr_config_id, Buffer.alloc(48))
+  t.deepEqual(body.mr_owner, Buffer.alloc(48))
+  t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
+
+  t.true(await verifyTdx(quote, { date: BASE_TIME, crls: [] }))
+})
+
+// ---------------------- Negative tests (replicated from v4) ----------------------
+
+test.serial("Reject a V5 TDX quote, missing root cert", async (t) => {
+  const quote = getV5QuoteBuffer()
+  const err = await t.throwsAsync(
+    async () =>
+      await verifyTdx(quote, {
+        pinnedRootCerts: [],
+        date: BASE_TIME,
+        crls: [],
+      }),
+  )
+  t.truthy(err)
+})
+
+test.serial("Reject a V5 TDX quote, missing intermediate cert", async (t) => {
+  const original = getV5QuoteBuffer()
+  const { leaf, root } = await getV5CertPems()
+  const noEmbedded = rebuildQuoteWithCertData(original, Buffer.alloc(0))
+  const err = await t.throwsAsync(
+    async () =>
+      await verifyTdx(noEmbedded, {
+        date: BASE_TIME,
+        extraCertdata: [leaf, root],
+        crls: [],
+      }),
+  )
+  t.truthy(err)
+})
+
+test.serial("Reject a V5 TDX quote, missing leaf cert", async (t) => {
+  const original = getV5QuoteBuffer()
+  const { intermediate, root } = await getV5CertPems()
+  const noEmbedded = rebuildQuoteWithCertData(original, Buffer.alloc(0))
+  const err = await t.throwsAsync(
+    async () =>
+      await verifyTdx(noEmbedded, {
+        date: BASE_TIME,
+        extraCertdata: [intermediate, root],
+        crls: [],
+      }),
+  )
+  t.truthy(err)
+})
+
+test.serial("Reject a V5 TDX quote, revoked root cert", async (t) => {
+  const { root } = await getV5CertPems()
+  const serial = normalizeSerialHex(new QV_X509Certificate(root).serialNumber)
+  const crl = buildCRLWithSerials([serial])
+  const err = await t.throwsAsync(
+    async () => await verifyTdx(getV5QuoteBuffer(), { date: BASE_TIME, crls: [crl] }),
+  )
+  t.truthy(err)
+})
+
+test.serial("Reject a V5 TDX quote, revoked intermediate cert", async (t) => {
+  const { intermediate } = await getV5CertPems()
+  const serial = normalizeSerialHex(new QV_X509Certificate(intermediate).serialNumber)
+  const crl = buildCRLWithSerials([serial])
+  const err = await t.throwsAsync(
+    async () => await verifyTdx(getV5QuoteBuffer(), { date: BASE_TIME, crls: [crl] }),
+  )
+  t.truthy(err)
+})
+
+test.serial("Reject a V5 TDX quote, revoked leaf cert", async (t) => {
+  const { leaf } = await getV5CertPems()
+  const serial = normalizeSerialHex(new QV_X509Certificate(leaf).serialNumber)
+  const crl = buildCRLWithSerials([serial])
+  const err = await t.throwsAsync(
+    async () => await verifyTdx(getV5QuoteBuffer(), { date: BASE_TIME, crls: [crl] }),
+  )
+  t.truthy(err)
+})
+
+test.serial("Reject a V5 TDX quote, invalid root self-signature", async (t) => {
+  const original = getV5QuoteBuffer()
+  const { leaf, intermediate, root } = await getV5CertPems()
+  const tamperedRoot = tamperPemSignature(root)
+  const noEmbedded = rebuildQuoteWithCertData(original, Buffer.alloc(0))
+  const err = await t.throwsAsync(
+    async () =>
+      await verifyTdx(noEmbedded, {
+        date: BASE_TIME,
+        extraCertdata: [leaf, intermediate, tamperedRoot],
+        crls: [],
+      }),
+  )
+  t.truthy(err)
+})
+
+test.serial("Reject a V5 TDX quote, invalid intermediate cert signature", async (t) => {
+  const original = getV5QuoteBuffer()
+  const { leaf, intermediate, root } = await getV5CertPems()
+  const tamperedIntermediate = tamperPemSignature(intermediate)
+  const noEmbedded = rebuildQuoteWithCertData(original, Buffer.alloc(0))
+  const err = await t.throwsAsync(
+    async () =>
+      await verifyTdx(noEmbedded, {
+        date: BASE_TIME,
+        extraCertdata: [leaf, tamperedIntermediate, root],
+        crls: [],
+      }),
+  )
+  t.truthy(err)
+})
+
+test.serial("Reject a V5 TDX quote, invalid leaf cert signature", async (t) => {
+  const original = getV5QuoteBuffer()
+  const { leaf, intermediate, root } = await getV5CertPems()
+  const tamperedLeaf = tamperPemSignature(leaf)
+  const noEmbedded = rebuildQuoteWithCertData(original, Buffer.alloc(0))
+  const err = await t.throwsAsync(
+    async () =>
+      await verifyTdx(noEmbedded, {
+        date: BASE_TIME,
+        extraCertdata: [tamperedLeaf, intermediate, root],
+        crls: [],
+      }),
+  )
+  t.truthy(err)
+})
+
+test.serial("Reject a V5 TDX quote, incorrect QE signature", async (t) => {
+  const original = Buffer.from(getV5QuoteBuffer())
+  const signedLen = getTdx10SignedRegion(original).length
+  const sigLen = original.readUInt32LE(signedLen)
+  const sigStart = signedLen + 4
+  const sigData = Buffer.from(original.subarray(sigStart, sigStart + sigLen))
+  const qeReportSigOffset = 64 + 64 + 6 + 384 // inside sig_data
+  sigData[qeReportSigOffset + 10] ^= 0x01
+  const mutated = Buffer.concat([
+    original.subarray(0, signedLen),
+    Buffer.from(
+      new Uint8Array([
+        sigData.length & 0xff,
+        (sigData.length >> 8) & 0xff,
+        (sigData.length >> 16) & 0xff,
+        (sigData.length >> 24) & 0xff,
+      ]),
+    ),
+    sigData,
+  ])
+  const err = await t.throwsAsync(
+    async () => await verifyTdx(mutated, { date: BASE_TIME, crls: [] }),
+  )
+  t.truthy(err)
+})
+
+test.serial("Reject a V5 TDX quote, incorrect QE binding", async (t) => {
+  const original = Buffer.from(getV5QuoteBuffer())
+  const signedLen = getTdx10SignedRegion(original).length
+  const sigLen = original.readUInt32LE(signedLen)
+  const sigStart = signedLen + 4
+  const sigData = Buffer.from(original.subarray(sigStart, sigStart + sigLen))
+  const attPubKeyOffset = 64 // inside sig_data
+  sigData[attPubKeyOffset + 0] ^= 0x01
+  const mutated = Buffer.concat([
+    original.subarray(0, signedLen),
+    Buffer.from(
+      new Uint8Array([
+        sigData.length & 0xff,
+        (sigData.length >> 8) & 0xff,
+        (sigData.length >> 16) & 0xff,
+        (sigData.length >> 24) & 0xff,
+      ]),
+    ),
+    sigData,
+  ])
+  const err = await t.throwsAsync(
+    async () => await verifyTdx(mutated, { date: BASE_TIME, crls: [] }),
+  )
+  t.truthy(err)
+})
+
+test.serial("Reject a V5 TDX quote, incorrect TD signature", async (t) => {
+  const original = Buffer.from(getV5QuoteBuffer())
+  const signedLen = getTdx10SignedRegion(original).length
+  const sigLen = original.readUInt32LE(signedLen)
+  const sigStart = signedLen + 4
+  const sigData = Buffer.from(original.subarray(sigStart, sigStart + sigLen))
+  const ecdsaSigOffset = 0 // inside sig_data
+  sigData[ecdsaSigOffset + 3] ^= 0x01
+  const mutated = Buffer.concat([
+    original.subarray(0, signedLen),
+    Buffer.from(
+      new Uint8Array([
+        sigData.length & 0xff,
+        (sigData.length >> 8) & 0xff,
+        (sigData.length >> 16) & 0xff,
+        (sigData.length >> 24) & 0xff,
+      ]),
+    ),
+    sigData,
+  ])
+  const err = await t.throwsAsync(
+    async () => await verifyTdx(mutated, { date: BASE_TIME, crls: [] }),
+  )
+  t.truthy(err)
+})
+
+test.serial("Reject a V5 TDX quote, missing certdata (no fallback)", async (t) => {
+  const base = getV5QuoteBuffer()
+  const noEmbedded = rebuildQuoteWithCertData(base, Buffer.alloc(0))
+  const err = await t.throwsAsync(
+    async () => await verifyTdx(noEmbedded, { date: BASE_TIME, crls: [] }),
+  )
+  t.truthy(err)
+})
+

--- a/test/qvl.test.ts
+++ b/test/qvl.test.ts
@@ -8,17 +8,21 @@ import {
   hex,
   reverseHexBytes,
   extractPemCertificates,
-  verifyPCKChain,
   verifyTdx,
   verifyTdxBase64,
   getTdx10SignedRegion,
-  computeCertSha256Hex,
-  verifySgx,
-  parseSgxQuote,
   normalizeSerialHex,
 } from "../qvl"
+import {
+  BASE_TIME,
+  tamperPemSignature,
+  buildCRLWithSerials,
+  rebuildQuoteWithCertData,
+  getGcpQuoteBase64,
+  getGcpCertPems,
+} from "./qvl-helpers"
 
-const BASE_TIME = Date.parse("2025-09-01")
+// BASE_TIME provided by helper
 
 test.serial("Verify a V4 TDX quote from Tappd", async (t) => {
   const quoteHex = fs.readFileSync("test/sample/tdx-v4-tappd.hex", "utf-8")
@@ -252,261 +256,8 @@ test.serial("Verify a V4 TDX quote from GCP", async (t) => {
   t.true(await verifyTdxBase64(quote, { date: BASE_TIME, crls: [] }))
 })
 
-test.serial("Verify a V5 TDX quote from Trustee", async (t) => {
-  const quote = fs.readFileSync("test/sample/tdx-v5-trustee.dat")
-  const { header, body } = parseTdxQuote(quote)
-
-  const expectedMRTD =
-    "dfba221b48a22af8511542ee796603f37382800840dcd978703909bf8e64d4c8a1e9de86e7c9638bfcba422f3886400a"
-  const expectedReportData =
-    "6d6ab13b046cff606ac0074be13981b07b6325dba10b5facc96febf551c0c3be2b75f92fe1f88f4bb996969ad0174b4b7a70261b7b85c844f4b33a4674fd049f"
-
-  t.is(header.version, 5)
-  t.is(header.tee_type, 129)
-  t.is(hex(body.mr_td), expectedMRTD)
-  t.is(hex(body.report_data), expectedReportData)
-  t.deepEqual(body.mr_config_id, Buffer.alloc(48))
-  t.deepEqual(body.mr_owner, Buffer.alloc(48))
-  t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
-
-  t.true(await verifyTdx(quote, { date: BASE_TIME, crls: [] }))
-})
-
-test.serial("Verify an SGX quote from Intel, no quote signature", async (t) => {
-  const quote = fs.readFileSync("test/sample/sgx/quote.dat")
-  const { header, body, signature } = parseSgxQuote(quote)
-
-  const expectedMrEnclave =
-    "0000000000000000000000000000000000000000000000000000000000000000"
-  const expectedReportData =
-    "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-
-  t.is(header.version, 3)
-  t.is(header.tee_type, 0)
-  t.is(hex(body.mr_enclave), expectedMrEnclave)
-  t.is(hex(body.report_data), expectedReportData)
-  t.deepEqual(body.mr_signer, Buffer.alloc(32))
-  t.deepEqual(body.attributes, Buffer.alloc(16))
-  t.deepEqual(body.cpu_svn, Buffer.alloc(16))
-
-  t.is(
-    hex(signature.ecdsa_signature),
-    "021a1375acdfc4520ade2f984b051e59a54e2892b24d3aa98e543b7b49eef2a375a7b5bafd1f1972e604fd799d4a01e2e422a52558768606daade2b17a6313ee",
-  )
-
-  // Intel sample is missing certdata, reconstruct it from provided PEM files instead
-  const root = extractPemCertificates(
-    fs.readFileSync("test/sample/sgx/trustedRootCaCert.pem"),
-  )
-  const pckChain = extractPemCertificates(
-    fs.readFileSync("test/sample/sgx/pckSignChain.pem"),
-  )
-  const pckCert = extractPemCertificates(
-    fs.readFileSync("test/sample/sgx/pckCert.pem"),
-  )
-  const certdata = [...root, ...pckChain, ...pckCert]
-
-  // Use provided certificate revocation lists
-  const crls = [
-    fs.readFileSync("test/sample/sgx/rootCaCrl.der"),
-    fs.readFileSync("test/sample/sgx/intermediateCaCrl.der"),
-  ]
-
-  t.true(
-    await verifySgx(quote, {
-      pinnedRootCerts: [new QV_X509Certificate(root[0])],
-      date: BASE_TIME,
-      crls,
-      extraCertdata: certdata,
-    }),
-  )
-})
-
-test.serial("Verify an SGX quote from Occlum", async (t) => {
-  const quote = fs.readFileSync("test/sample/sgx-occlum.dat")
-  const { header, body } = parseSgxQuote(quote)
-
-  const expectedMrEnclave =
-    "9c90fd81f6e9fe64b46b14f0623523a52d6a5678482988c408f6adffe6301e2c"
-  const expectedReportData =
-    "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-
-  t.is(header.version, 3)
-  t.is(header.tee_type, 0)
-  t.is(hex(body.mr_enclave), expectedMrEnclave)
-  t.is(hex(body.report_data), expectedReportData)
-
-  t.true(await verifySgx(quote, { date: BASE_TIME, crls: [] }))
-})
-
-test.serial("Verify an SGX quote from chinenyeokafor", async (t) => {
-  const quote = fs.readFileSync("test/sample/sgx-chinenyeokafor.dat")
-  const { header, body } = parseSgxQuote(quote)
-
-  const expectedMrEnclave =
-    "0696ab235b2d339e68a4303cb64cde005bb8cdf2448bed742ac8ea8339bd0cb7"
-  const expectedReportData =
-    "888d97435fd51947e5a8c71f73ba24d9abcf716a1ac05b495a54f9a6fb54609e0000000000000000000000000000000000000000000000000000000000000000"
-
-  t.is(header.version, 3)
-  t.is(header.tee_type, 0)
-  t.is(hex(body.mr_enclave), expectedMrEnclave)
-  t.is(hex(body.report_data), expectedReportData)
-
-  t.true(await verifySgx(quote, { date: BASE_TIME, crls: [] }))
-})
-
-test.serial("Verify an SGX quote from TLSN, quote9", async (t) => {
-  const quote = fs.readFileSync("test/sample/sgx-tlsn-quote9.dat")
-  const { header, body } = parseSgxQuote(quote)
-
-  const expectedMrEnclave =
-    "50a6a608c1972408f94379f83a7af2ea55b31095f131efe93af74f5968a44f29"
-  const expectedReportData =
-    "03351d6944f43d3041a075bddf540d2b91595979ef67fee8c9e6f1c3a5ff6e9e7300000000000000000000000000000000000000000000000000000000000000"
-
-  t.is(header.version, 3)
-  t.is(header.tee_type, 0)
-  t.is(hex(body.mr_enclave), expectedMrEnclave)
-  t.is(hex(body.report_data), expectedReportData)
-
-  t.true(await verifySgx(quote, { date: BASE_TIME, crls: [] }))
-})
-
-test.serial("Verify an SGX quote from TLSN, quote_dev", async (t) => {
-  const quote = fs.readFileSync("test/sample/sgx-tlsn-quotedev.dat")
-  const { header, body } = parseSgxQuote(quote)
-
-  const expectedMrEnclave =
-    "db5e55d3190d92512e4eae09d697b4b5fe30c2212e1ad6db5681379608c46204"
-  const expectedReportData =
-    "030eba01d248d2c2fb4f39fc8f2daaf2392560100989eb022dc6570e87a011b29c00000000000000000000000000000000000000000000000000000000000000"
-
-  t.is(header.version, 3)
-  t.is(header.tee_type, 0)
-  t.is(hex(body.mr_enclave), expectedMrEnclave)
-  t.is(hex(body.report_data), expectedReportData)
-
-  t.true(await verifySgx(quote, { date: BASE_TIME, crls: [] }))
-})
 
 // ---------------------- Negative tests for invalid scenarios ----------------------
-
-function pemToDer(pem: string): Buffer {
-  const b64 = pem
-    .replace(/-----BEGIN CERTIFICATE-----/g, "")
-    .replace(/-----END CERTIFICATE-----/g, "")
-    .replace(/\s+/g, "")
-  return Buffer.from(b64, "base64")
-}
-
-function derToPem(der: Buffer): string {
-  const b64 = der.toString("base64")
-  const lines = b64.match(/.{1,64}/g) || []
-  return `-----BEGIN CERTIFICATE-----\n${lines.join(
-    "\n",
-  )}\n-----END CERTIFICATE-----\n`
-}
-
-function tamperPemSignature(pem: string): string {
-  const der = Buffer.from(pemToDer(pem))
-  der[der.length - 1] ^= 0x01
-  return derToPem(der)
-}
-
-function buildCRLWithSerials(serialsUpperHex: string[]): Buffer {
-  const encodeLen = (len: number) => {
-    if (len < 0x80) return Buffer.from([len])
-    const bytes: number[] = []
-    let v = len
-    while (v > 0) {
-      bytes.unshift(v & 0xff)
-      v >>= 8
-    }
-    return Buffer.from([0x80 | bytes.length, ...bytes])
-  }
-  const tlv = (tag: number, value: Buffer) =>
-    Buffer.concat([Buffer.from([tag]), encodeLen(value.length), value])
-
-  const encodeIntegerHex = (hex: string) => {
-    let v = Buffer.from(hex.replace(/[^0-9A-F]/g, ""), "hex")
-    if (v.length === 0) v = Buffer.from([0])
-    if (v[0] & 0x80) v = Buffer.concat([Buffer.from([0x00]), v])
-    return tlv(0x02, v)
-  }
-
-  const version = tlv(0x02, Buffer.from([0x01]))
-  const sigAlg = tlv(0x30, Buffer.alloc(0))
-  const issuer = tlv(0x30, Buffer.alloc(0))
-  const thisUpdate = tlv(0x17, Buffer.from("250101000000Z"))
-
-  const revokedEntries = serialsUpperHex.map((s) =>
-    tlv(0x30, encodeIntegerHex(s)),
-  )
-  const revokedSeq = tlv(0x30, Buffer.concat(revokedEntries))
-
-  const tbs = tlv(
-    0x30,
-    Buffer.concat([version, sigAlg, issuer, thisUpdate, revokedSeq]),
-  )
-  const outer = tlv(0x30, tbs)
-  return outer
-}
-
-function rebuildQuoteWithCertData(baseQuote: Buffer, certData: Buffer): Buffer {
-  const signedLen = getTdx10SignedRegion(baseQuote).length
-  const sigLen = baseQuote.readUInt32LE(signedLen)
-  const sigStart = signedLen + 4
-  const sigData = baseQuote.subarray(sigStart, sigStart + sigLen)
-
-  const FIXED_LEN = 64 + 64 + 6 + 384 + 64 + 2 // ECDSA fixed portion
-  const qeAuthLen = sigData.readUInt16LE(64 + 64 + 6 + 384 + 64)
-  const fixedPlusAuth = sigData.subarray(0, FIXED_LEN + qeAuthLen)
-
-  const tail = Buffer.alloc(2 + 4)
-  tail.writeUInt16LE(5, 0) // cert_data_type = 5 (PCK)
-  tail.writeUInt32LE(certData.length, 2)
-
-  const newSigData = Buffer.concat([fixedPlusAuth, tail, certData])
-  const newSigLen = Buffer.alloc(4)
-  newSigLen.writeUInt32LE(newSigData.length, 0)
-
-  const prefix = baseQuote.subarray(0, signedLen)
-  return Buffer.concat([prefix, newSigLen, newSigData])
-}
-
-function getGcpQuoteBase64(): string {
-  const data = JSON.parse(
-    fs.readFileSync("test/sample/tdx-v4-gcp.json", "utf-8"),
-  )
-  return data.tdx.quote as string
-}
-
-async function getGcpCertPems(): Promise<{
-  leaf: string
-  intermediate: string
-  root: string
-  all: string[]
-}> {
-  const quoteB64 = getGcpQuoteBase64()
-  const { signature } = parseTdxQuoteBase64(quoteB64)
-  const pems = extractPemCertificates(signature.cert_data)
-  const { chain } = await verifyPCKChain(pems, null)
-  const hashToPem = new Map<string, string>()
-  for (const pem of pems) {
-    const h = await computeCertSha256Hex(new QV_X509Certificate(pem))
-    hashToPem.set(h, pem)
-  }
-  const leafPem = hashToPem.get(await computeCertSha256Hex(chain[0]))!
-  const intermediatePem = hashToPem.get(await computeCertSha256Hex(chain[1]))!
-  const rootPem = hashToPem.get(await computeCertSha256Hex(chain[2]))!
-  return {
-    leaf: leafPem,
-    intermediate: intermediatePem,
-    root: rootPem,
-    all: pems,
-  }
-}
 
 test.serial("Reject a V4 TDX quote, missing root cert", async (t) => {
   const quoteB64 = getGcpQuoteBase64()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "noFallthroughCasesInSwitch": true,
 
     /* Types */
-    "typeRoots": ["./types", "./node_modules/@types"]
+    "typeRoots": ["./types", "./node_modules/@types"],
+    "types": ["node"]
   },
-  "include": ["src", "qvl", "tunnel"]
+  "include": ["src", "qvl", "tunnel", "test"]
 }


### PR DESCRIPTION
Refactor QVL test suite by separating SGX and TDXv5 tests into dedicated files and extracting shared helpers.

This improves test organization, expands TDXv5 negative test coverage by replicating the TDXv4 suite, and resolves TypeScript type issues in the test directory.

---
<a href="https://cursor.com/background-agent?bcId=bc-b17357ef-15fc-42d7-8bdd-e070fb9b9909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b17357ef-15fc-42d7-8bdd-e070fb9b9909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

