### PR TITLE
Refactor validation tests to use trustee example

### DIFF
--- a/test/qvl-helpers.ts
+++ b/test/qvl-helpers.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import {
   getTdx10SignedRegion,
+  getTdx15SignedRegion,
   parseTdxQuote,
   extractPemCertificates,
   verifyPCKChain,
@@ -71,7 +72,11 @@ export function rebuildQuoteWithCertData(
   baseQuote: Buffer,
   certData: Buffer,
 ): Buffer {
-  const signedLen = getTdx10SignedRegion(baseQuote).length
+  const { header } = parseTdxQuote(baseQuote)
+  const signedLen =
+    header.version === 5
+      ? getTdx15SignedRegion(baseQuote).length
+      : getTdx10SignedRegion(baseQuote).length
   const sigLen = baseQuote.readUInt32LE(signedLen)
   const sigStart = signedLen + 4
   const sigData = baseQuote.subarray(sigStart, sigStart + sigLen)

--- a/test/qvl-tdxv5.test.ts
+++ b/test/qvl-tdxv5.test.ts
@@ -3,20 +3,16 @@ import fs from "node:fs"
 import {
   hex,
   parseTdxQuote,
-  parseTdxQuoteBase64,
   verifyTdx,
-  verifyTdxBase64,
-  getTdx10SignedRegion,
+  getTdx15SignedRegion,
   QV_X509Certificate,
-  extractPemCertificates,
-  verifyPCKChain,
-  computeCertSha256Hex,
   normalizeSerialHex,
 } from "../qvl/index.js"
 import {
   rebuildQuoteWithCertData,
   tamperPemSignature,
   buildCRLWithSerials,
+  getCertPemsFromTdxQuoteBufferImpl,
 } from "./qvl-helpers.js"
 
 const BASE_TIME = Date.parse("2025-09-01")
@@ -41,52 +37,26 @@ test.serial("Verify a V5 TDX quote from Trustee", async (t) => {
   t.true(await verifyTdx(quote, { date: BASE_TIME, crls: [] }))
 })
 
-// Replicate negative tests from TDXv4 suite for V5 by using a base64 quote sample
-// We currently only have a V4 GCP base64 sample; the structural checks apply to V5 too
-// by mutating the same fields. We upgrade header.version to 5 where relevant.
-
-function getGcpQuoteBase64(): string {
-  const data = JSON.parse(
-    fs.readFileSync("test/sample/tdx-v4-gcp.json", "utf-8"),
-  )
-  return data.tdx.quote as string
+// Use the Trustee V5 binary quote for all negative tests
+function getTrusteeQuote(): Buffer {
+  return fs.readFileSync("test/sample/tdx-v5-trustee.dat")
 }
 
-async function getGcpCertPems(): Promise<{
+async function getTrusteeCertPems(): Promise<{
   leaf: string
   intermediate: string
   root: string
   all: string[]
 }> {
-  const quoteB64 = getGcpQuoteBase64()
-  const { signature } = parseTdxQuoteBase64(quoteB64)
-  const pems = extractPemCertificates(signature.cert_data)
-  const { chain } = await verifyPCKChain(pems, null)
-  const hashToPem = new Map<string, string>()
-  for (const pem of pems) {
-    const h = await computeCertSha256Hex(new QV_X509Certificate(pem))
-    hashToPem.set(h, pem)
-  }
-  const leafPem = hashToPem.get(await computeCertSha256Hex(chain[0]))!
-  const intermediatePem = hashToPem.get(await computeCertSha256Hex(chain[1]))!
-  const rootPem = hashToPem.get(await computeCertSha256Hex(chain[2]))!
-  return {
-    leaf: leafPem,
-    intermediate: intermediatePem,
-    root: rootPem,
-    all: pems,
-  }
+  const quote = getTrusteeQuote()
+  return getCertPemsFromTdxQuoteBufferImpl(quote)
 }
 
 test.serial("Reject a V5 TDX quote, missing root cert", async (t) => {
-  const quoteB64 = getGcpQuoteBase64()
-  // bump version to 5
-  const buf = Buffer.from(quoteB64, "base64")
-  buf.writeUInt16LE(5, 0)
-  const b64v5 = buf.toString("base64")
+  const buf = getTrusteeQuote()
   const err = await t.throwsAsync(
     async () =>
-      await verifyTdxBase64(b64v5, {
+      await verifyTdx(buf, {
         pinnedRootCerts: [],
         date: BASE_TIME,
         crls: [],
@@ -97,10 +67,8 @@ test.serial("Reject a V5 TDX quote, missing root cert", async (t) => {
 })
 
 test.serial("Reject a V5 TDX quote, missing intermediate cert", async (t) => {
-  const quoteB64 = getGcpQuoteBase64()
-  const buf = Buffer.from(quoteB64, "base64")
-  buf.writeUInt16LE(5, 0)
-  const { leaf, root } = await getGcpCertPems()
+  const buf = getTrusteeQuote()
+  const { leaf, root } = await getTrusteeCertPems()
   const noEmbedded = rebuildQuoteWithCertData(buf, Buffer.alloc(0))
   const err = await t.throwsAsync(
     async () =>
@@ -115,10 +83,8 @@ test.serial("Reject a V5 TDX quote, missing intermediate cert", async (t) => {
 })
 
 test.serial("Reject a V5 TDX quote, missing leaf cert", async (t) => {
-  const quoteB64 = getGcpQuoteBase64()
-  const buf = Buffer.from(quoteB64, "base64")
-  buf.writeUInt16LE(5, 0)
-  const { intermediate, root } = await getGcpCertPems()
+  const buf = getTrusteeQuote()
+  const { intermediate, root } = await getTrusteeCertPems()
   const noEmbedded = rebuildQuoteWithCertData(buf, Buffer.alloc(0))
   const err = await t.throwsAsync(
     async () =>
@@ -133,17 +99,15 @@ test.serial("Reject a V5 TDX quote, missing leaf cert", async (t) => {
 })
 
 test.serial("Reject a V5 TDX quote, revoked root cert", async (t) => {
-  const quoteB64 = getGcpQuoteBase64()
-  const buf = Buffer.from(quoteB64, "base64")
-  buf.writeUInt16LE(5, 0)
-  const { root } = await getGcpCertPems()
+  const buf = getTrusteeQuote()
+  const { root } = await getTrusteeCertPems()
   const rootSerial = normalizeSerialHex(
     new QV_X509Certificate(root).serialNumber,
   )
   const crl = buildCRLWithSerials([rootSerial])
   const err = await t.throwsAsync(
     async () =>
-      await verifyTdxBase64(buf.toString("base64"), {
+      await verifyTdx(buf, {
         date: BASE_TIME,
         crls: [crl],
       }),
@@ -153,10 +117,8 @@ test.serial("Reject a V5 TDX quote, revoked root cert", async (t) => {
 })
 
 test.serial("Reject a V5 TDX quote, invalid root self-signature", async (t) => {
-  const quoteB64 = getGcpQuoteBase64()
-  const buf = Buffer.from(quoteB64, "base64")
-  buf.writeUInt16LE(5, 0)
-  const { leaf, intermediate, root } = await getGcpCertPems()
+  const buf = getTrusteeQuote()
+  const { leaf, intermediate, root } = await getTrusteeCertPems()
   const tamperedRoot = tamperPemSignature(root)
   const noEmbedded = rebuildQuoteWithCertData(buf, Buffer.alloc(0))
   const err = await t.throwsAsync(
@@ -172,10 +134,8 @@ test.serial("Reject a V5 TDX quote, invalid root self-signature", async (t) => {
 })
 
 test.serial("Reject a V5 TDX quote, incorrect QE signature", async (t) => {
-  const quoteB64 = getGcpQuoteBase64()
-  const original = Buffer.from(quoteB64, "base64")
-  original.writeUInt16LE(5, 0)
-  const signedLen = getTdx10SignedRegion(original).length
+  const original = Buffer.from(getTrusteeQuote())
+  const signedLen = getTdx15SignedRegion(original).length
   const sigLen = original.readUInt32LE(signedLen)
   const sigStart = signedLen + 4
   const sigData = Buffer.from(original.subarray(sigStart, sigStart + sigLen))
@@ -201,10 +161,8 @@ test.serial("Reject a V5 TDX quote, incorrect QE signature", async (t) => {
 })
 
 test.serial("Reject a V5 TDX quote, incorrect QE binding", async (t) => {
-  const quoteB64 = getGcpQuoteBase64()
-  const original = Buffer.from(quoteB64, "base64")
-  original.writeUInt16LE(5, 0)
-  const signedLen = getTdx10SignedRegion(original).length
+  const original = Buffer.from(getTrusteeQuote())
+  const signedLen = getTdx15SignedRegion(original).length
   const sigLen = original.readUInt32LE(signedLen)
   const sigStart = signedLen + 4
   const sigData = Buffer.from(original.subarray(sigStart, sigStart + sigLen))
@@ -230,10 +188,8 @@ test.serial("Reject a V5 TDX quote, incorrect QE binding", async (t) => {
 })
 
 test.serial("Reject a V5 TDX quote, incorrect TD signature", async (t) => {
-  const quoteB64 = getGcpQuoteBase64()
-  const original = Buffer.from(quoteB64, "base64")
-  original.writeUInt16LE(5, 0)
-  const signedLen = getTdx10SignedRegion(original).length
+  const original = Buffer.from(getTrusteeQuote())
+  const signedLen = getTdx15SignedRegion(original).length
   const sigLen = original.readUInt32LE(signedLen)
   const sigStart = signedLen + 4
   const sigData = Buffer.from(original.subarray(sigStart, sigStart + sigLen))
@@ -259,10 +215,8 @@ test.serial("Reject a V5 TDX quote, incorrect TD signature", async (t) => {
 })
 
 test.serial("Reject a V5 TDX quote, unsupported cert_data_type", async (t) => {
-  const quoteB64 = getGcpQuoteBase64()
-  const original = Buffer.from(quoteB64, "base64")
-  original.writeUInt16LE(5, 0)
-  const signedLen = getTdx10SignedRegion(original).length
+  const original = Buffer.from(getTrusteeQuote())
+  const signedLen = getTdx15SignedRegion(original).length
   const sigLen = original.readUInt32LE(signedLen)
   const sigStart = signedLen + 4
   const sigData = Buffer.from(original.subarray(sigStart, sigStart + sigLen))
@@ -296,9 +250,7 @@ test.serial("Reject a V5 TDX quote, unsupported cert_data_type", async (t) => {
 test.serial(
   "Reject a V5 TDX quote, missing certdata (no fallback)",
   async (t) => {
-    const quoteB64 = getGcpQuoteBase64()
-    const base = Buffer.from(quoteB64, "base64")
-    base.writeUInt16LE(5, 0)
+    const base = Buffer.from(getTrusteeQuote())
     const noEmbedded = rebuildQuoteWithCertData(base, Buffer.alloc(0))
     const err = await t.throwsAsync(
       async () => await verifyTdx(noEmbedded, { date: BASE_TIME, crls: [] }),
@@ -311,9 +263,7 @@ test.serial(
 test.serial(
   "Reject a V5 TDX quote, cert chain not yet valid (too early)",
   async (t) => {
-    const quoteB64 = getGcpQuoteBase64()
-    const buf = Buffer.from(quoteB64, "base64")
-    buf.writeUInt16LE(5, 0)
+    const buf = Buffer.from(getTrusteeQuote())
     const early = Date.parse("2000-01-01")
     const err = await t.throwsAsync(
       async () => await verifyTdx(buf, { date: early, crls: [] }),
@@ -326,9 +276,7 @@ test.serial(
 test.serial(
   "Reject a V5 TDX quote, cert chain expired (too late)",
   async (t) => {
-    const quoteB64 = getGcpQuoteBase64()
-    const buf = Buffer.from(quoteB64, "base64")
-    buf.writeUInt16LE(5, 0)
+    const buf = Buffer.from(getTrusteeQuote())
     const late = Date.parse("2100-01-01")
     const err = await t.throwsAsync(
       async () => await verifyTdx(buf, { date: late, crls: [] }),
@@ -339,17 +287,15 @@ test.serial(
 )
 
 test.serial("Reject a V5 TDX quote, revoked intermediate cert", async (t) => {
-  const quoteB64 = getGcpQuoteBase64()
-  const buf = Buffer.from(quoteB64, "base64")
-  buf.writeUInt16LE(5, 0)
-  const { intermediate } = await getGcpCertPems()
+  const buf = getTrusteeQuote()
+  const { intermediate } = await getTrusteeCertPems()
   const serial = normalizeSerialHex(
     new QV_X509Certificate(intermediate).serialNumber,
   )
   const crl = buildCRLWithSerials([serial])
   const err = await t.throwsAsync(
     async () =>
-      await verifyTdxBase64(buf.toString("base64"), {
+      await verifyTdx(buf, {
         date: BASE_TIME,
         crls: [crl],
       }),
@@ -359,15 +305,13 @@ test.serial("Reject a V5 TDX quote, revoked intermediate cert", async (t) => {
 })
 
 test.serial("Reject a V5 TDX quote, revoked leaf cert", async (t) => {
-  const quoteB64 = getGcpQuoteBase64()
-  const buf = Buffer.from(quoteB64, "base64")
-  buf.writeUInt16LE(5, 0)
-  const { leaf } = await getGcpCertPems()
+  const buf = getTrusteeQuote()
+  const { leaf } = await getTrusteeCertPems()
   const serial = normalizeSerialHex(new QV_X509Certificate(leaf).serialNumber)
   const crl = buildCRLWithSerials([serial])
   const err = await t.throwsAsync(
     async () =>
-      await verifyTdxBase64(buf.toString("base64"), {
+      await verifyTdx(buf, {
         date: BASE_TIME,
         crls: [crl],
       }),
@@ -377,9 +321,7 @@ test.serial("Reject a V5 TDX quote, revoked leaf cert", async (t) => {
 })
 
 test.serial("Reject a V5 TDX quote, unsupported TEE type", async (t) => {
-  const quoteB64 = getGcpQuoteBase64()
-  const original = Buffer.from(quoteB64, "base64")
-  original.writeUInt16LE(5, 0)
+  const original = Buffer.from(getTrusteeQuote())
   // header.tee_type at offset 4 (UInt32LE)
   original.writeUInt32LE(0, 4)
   const err = await t.throwsAsync(
@@ -392,9 +334,7 @@ test.serial("Reject a V5 TDX quote, unsupported TEE type", async (t) => {
 test.serial(
   "Reject a V5 TDX quote, unsupported attestation key type",
   async (t) => {
-    const quoteB64 = getGcpQuoteBase64()
-    const original = Buffer.from(quoteB64, "base64")
-    original.writeUInt16LE(5, 0)
+    const original = Buffer.from(getTrusteeQuote())
     // header.att_key_type at offset 2 (UInt16LE)
     original.writeUInt16LE(1, 2)
     const err = await t.throwsAsync(
@@ -406,8 +346,7 @@ test.serial(
 )
 
 test.serial("Reject a TDX v5 quote with unsupported version", async (t) => {
-  const quoteB64 = getGcpQuoteBase64()
-  const original = Buffer.from(quoteB64, "base64")
+  const original = Buffer.from(getTrusteeQuote())
   // header.version at offset 0 (UInt16LE)
   original.writeUInt16LE(6, 0)
   const err = await t.throwsAsync(


### PR DESCRIPTION
Rewrite TDX V5 validation rejection tests to use the Trustee binary quote example for consistency and direct relevance.

---
<a href="https://cursor.com/background-agent?bcId=bc-cdac8087-8cc8-433b-8953-6a66f68eb1dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cdac8087-8cc8-433b-8953-6a66f68eb1dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

