### PR TITLE
Run and fix fetch api tests

### DIFF
--- a/packages/tunnel/src/server.ts
+++ b/packages/tunnel/src/server.ts
@@ -302,11 +302,14 @@ export class TunnelServer {
         url: tunnelReq.url,
         path: urlObj.pathname,
         headers: tunnelReq.headers,
-        body: tunnelReq.body
-          ? parseBody(tunnelReq.body, tunnelReq.headers["content-type"])
-          : undefined,
         query: query,
       })
+
+      // Ensure req.body is set exactly to the parsed body, including empty string
+      ;(req as any).body =
+        tunnelReq.body !== undefined
+          ? parseBody(tunnelReq.body, tunnelReq.headers["content-type"])
+          : undefined
 
       const res = httpMocks.createResponse({
         eventEmitter: EventEmitter,


### PR DESCRIPTION
Fix failing fetch API tests by improving client `fetch()` compatibility and ensuring the server preserves empty string bodies.

The `fetch.test.ts` suite revealed two main issues:
1. The `TunnelClient.fetch` method did not properly parse `Request` objects as input, nor did it correctly handle `ReadableStream` or `Buffer`-like bodies, leading to data not being sent or being sent incorrectly.
2. The `TunnelServer` was not explicitly setting `req.body` when the parsed body was an empty string, causing PATCH requests with empty bodies to be misinterpreted. These changes resolve these incompatibilities and ensure all fetch tests pass.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a7fc8d0-6d2b-44dd-ab77-b5b752dc6d9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9a7fc8d0-6d2b-44dd-ab77-b5b752dc6d9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

