### PR TITLE
Intercept and tunnel non-tunneled requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7858,8 +7858,10 @@
       "name": "ra-https-demo",
       "version": "0.0.0",
       "dependencies": {
+        "cbor-x": "^1.6.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
+        "libsodium-wrappers": "^0.7.15",
         "ra-https-qvl": "0.0.0",
         "ra-https-tunnel": "0.0.0",
         "react": "^19.1.1",

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -13,6 +13,8 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^5.1.0",
+    "cbor-x": "^1.6.0",
+    "libsodium-wrappers": "^0.7.15",
     "ra-https-qvl": "0.0.0",
     "ra-https-tunnel": "0.0.0",
     "react": "^19.1.1",

--- a/packages/demo/server/server.ts
+++ b/packages/demo/server/server.ts
@@ -23,6 +23,7 @@ let messages: Message[] = []
 let totalMessageCount = 0
 const MAX_MESSAGES = 30
 const startTime = Date.now()
+let counter = 0
 
 // API Routes
 app.get("/uptime", (_req, res) => {
@@ -42,6 +43,11 @@ app.get("/uptime", (_req, res) => {
       }s`,
     },
   })
+})
+
+app.post("/increment", (_req, res) => {
+  counter += 1
+  res.json({ counter })
 })
 
 wss.on("connection", (ws: WebSocket) => {

--- a/packages/demo/src/App.tsx
+++ b/packages/demo/src/App.tsx
@@ -39,6 +39,8 @@ function App() {
   const [uptime, setUptime] = useState<string>("")
   const [hiddenMessagesCount, setHiddenMessagesCount] = useState<number>(0)
   const [verifyResult, setVerifyResult] = useState<string>("")
+  const [swUptime, setSwUptime] = useState<string>("")
+  const [swCounter, setSwCounter] = useState<number>(0)
   const wsRef = useRef<WebSocket | null>(null)
   const messagesEndRef = useRef<HTMLDivElement | null>(null)
   const inputRef = useRef<HTMLInputElement | null>(null)
@@ -216,6 +218,38 @@ function App() {
           >
             Disconnect
           </a>
+        </div>
+      </div>
+
+      <div style={{ margin: "12px 0", padding: 12, border: "1px solid #ddd", borderRadius: 8 }}>
+        <div style={{ fontWeight: 600, marginBottom: 6 }}>ServiceWorker tunnel test (native fetch)</div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <button
+            onClick={async () => {
+              try {
+                const r = await fetch("/uptime")
+                const j = await r.json()
+                setSwUptime(j?.uptime?.formatted || "")
+              } catch {}
+            }}
+          >
+            GET /uptime
+          </button>
+          <button
+            onClick={async () => {
+              try {
+                const r = await fetch("/increment", { method: "POST", headers: { "content-type": "application/json" }, body: "{}" })
+                const j = await r.json()
+                setSwCounter(j?.counter || 0)
+              } catch {}
+            }}
+          >
+            POST /increment
+          </button>
+        </div>
+        <div style={{ marginTop: 8, fontSize: "0.9em", color: "#333" }}>
+          <div>Uptime (via SW): {swUptime || "—"}</div>
+          <div>Counter (via SW): {swCounter}</div>
         </div>
       </div>
 

--- a/packages/demo/src/main.tsx
+++ b/packages/demo/src/main.tsx
@@ -8,3 +8,20 @@ createRoot(document.getElementById("root")!).render(
     <App />
   </StrictMode>,
 )
+
+// Register Service Worker for tunneling same-origin fetch requests
+if ("serviceWorker" in navigator) {
+  const target =
+    document.location.hostname === "localhost"
+      ? "http://localhost:3001"
+      : "https://ra-https.up.railway.app"
+
+  // During Vite dev, entries are served from /src/...; in build they're emitted at root
+  const dev = import.meta && (import.meta as any).env && (import.meta as any).env.DEV
+  const swPath = dev ? "/src/sw/tunnel-sw.ts" : "/tunnel-sw.js"
+  const swUrl = `${swPath}?target=${encodeURIComponent(target)}`
+
+  navigator.serviceWorker
+    .register(swUrl, { type: "module", scope: "/" })
+    .catch(() => {})
+}

--- a/packages/demo/src/sw/tunnel-sw.ts
+++ b/packages/demo/src/sw/tunnel-sw.ts
@@ -1,0 +1,273 @@
+/// <reference lib="webworker" />
+/* eslint-env serviceworker */
+declare const self: ServiceWorkerGlobalScope
+
+// Minimal encrypted tunnel client inside a Service Worker.
+// Reads target origin from the ServiceWorker script URL query: ?target=...
+
+import sodium from "libsodium-wrappers"
+import { encode, decode } from "cbor-x"
+
+type RAEncryptedHTTPRequest = {
+  type: "http_request"
+  requestId: string
+  method: string
+  url: string
+  headers: Record<string, string>
+  body?: string
+}
+
+type RAEncryptedHTTPResponse = {
+  type: "http_response"
+  requestId: string
+  status: number
+  statusText: string
+  headers: Record<string, string>
+  body?: string | Uint8Array
+  error?: string
+}
+
+type ControlChannelKXConfirm = {
+  type: "client_kx"
+  sealedSymmetricKey: string
+}
+
+type ControlChannelEncryptedMessage = {
+  type: "enc"
+  nonce: Uint8Array
+  ciphertext: Uint8Array
+}
+
+// Parse configuration from script URL
+const swUrl = new URL(self.location.href)
+const TARGET_ORIGIN = swUrl.searchParams.get("target") || self.location.origin
+
+let ws: WebSocket | null = null
+let symmetricKey: Uint8Array | undefined
+let connectionPromise: Promise<void> | null = null
+const pendingRequests = new Map<
+  string,
+  { resolve: (response: Response) => void; reject: (error: Error) => void }
+>()
+
+function generateRequestId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+}
+
+async function ensureConnection(): Promise<void> {
+  if (ws && ws.readyState === WebSocket.OPEN && symmetricKey) return
+  if (connectionPromise) return connectionPromise
+
+  await sodium.ready
+
+  connectionPromise = new Promise<void>((resolve, reject) => {
+    const url = new URL(TARGET_ORIGIN)
+    url.protocol = url.protocol.replace(/^http/, "ws")
+    url.pathname = "/__ra__"
+
+    ws = new WebSocket(url.toString())
+    ws.binaryType = "arraybuffer"
+
+    ws.onopen = () => {
+      // Wait for server_kx before resolving
+    }
+
+    ws.onmessage = async (event) => {
+      try {
+        const bytes = event.data instanceof ArrayBuffer
+          ? new Uint8Array(event.data)
+          : new Uint8Array(await event.data.arrayBuffer?.())
+        let message: any = decode(bytes)
+
+        if (message && message.type === "server_kx") {
+          try {
+            const serverPub = sodium.from_base64(
+              message.x25519PublicKey,
+              sodium.base64_variants.ORIGINAL,
+            )
+            const key = sodium.crypto_secretbox_keygen()
+            const sealed = sodium.crypto_box_seal(key, serverPub)
+            symmetricKey = key
+
+            const reply: ControlChannelKXConfirm = {
+              type: "client_kx",
+              sealedSymmetricKey: sodium.to_base64(
+                sealed,
+                sodium.base64_variants.ORIGINAL,
+              ),
+            }
+            ws!.send(encode(reply))
+
+            connectionPromise = null
+            resolve()
+          } catch (e) {
+            connectionPromise = null
+            reject(e as Error)
+          }
+          return
+        }
+
+        if (message && message.type === "enc") {
+          if (!symmetricKey) return
+          const nonce: Uint8Array = message.nonce
+          const ciphertext: Uint8Array = message.ciphertext
+          const plaintext = sodium.crypto_secretbox_open_easy(
+            ciphertext,
+            nonce,
+            symmetricKey,
+          )
+          message = decode(plaintext)
+
+          if (message && message.type === "http_response") {
+            const res = message as RAEncryptedHTTPResponse
+            const pending = pendingRequests.get(res.requestId)
+            if (!pending) return
+            pendingRequests.delete(res.requestId)
+
+            if (res.error) {
+              pending.reject(new Error(res.error))
+              return
+            }
+
+            const body = res.status === 204 ? null : res.body ?? null
+            const response = new Response(body as any, {
+              status: res.status,
+              statusText: res.statusText,
+              headers: res.headers,
+            })
+            pending.resolve(response)
+            return
+          }
+        }
+      } catch (err) {
+        // Drop malformed messages
+      }
+    }
+
+    ws.onclose = () => {
+      connectionPromise = null
+      symmetricKey = undefined
+      try {
+        for (const [, p] of pendingRequests.entries()) {
+          p.reject(new Error("Tunnel disconnected"))
+        }
+      } finally {
+        pendingRequests.clear()
+      }
+    }
+
+    ws.onerror = () => {
+      const err = new Error("WebSocket connection failed")
+      connectionPromise = null
+      try {
+        for (const [, p] of pendingRequests.entries()) {
+          p.reject(err)
+        }
+      } finally {
+        pendingRequests.clear()
+      }
+      reject(err)
+    }
+  })
+
+  return connectionPromise
+}
+
+function encryptPayload(payload: any): ControlChannelEncryptedMessage {
+  if (!symmetricKey) throw new Error("Missing symmetric key")
+  const nonce = sodium.randombytes_buf(sodium.crypto_secretbox_NONCEBYTES)
+  const plaintext = encode(payload)
+  const ciphertext = sodium.crypto_secretbox_easy(plaintext, nonce, symmetricKey)
+  return { type: "enc", nonce, ciphertext }
+}
+
+async function tunnelFetch(request: Request): Promise<Response> {
+  await ensureConnection()
+
+  // Build absolute URL targeting the configured origin
+  const reqUrl = new URL(request.url)
+  const tgt = new URL(TARGET_ORIGIN)
+  const forwardUrl = `${tgt.origin}${reqUrl.pathname}${reqUrl.search}`
+
+  // Collect headers
+  const headers: Record<string, string> = {}
+  request.headers.forEach((value, key) => {
+    headers[key] = value
+  })
+
+  // Read body as string where applicable
+  let body: string | undefined
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    const ab = await request.arrayBuffer()
+    if (ab && ab.byteLength > 0) {
+      body = new TextDecoder().decode(new Uint8Array(ab))
+    }
+  }
+
+  const requestId = generateRequestId()
+  const payload: RAEncryptedHTTPRequest = {
+    type: "http_request",
+    requestId,
+    method: request.method,
+    url: forwardUrl,
+    headers,
+    body,
+  }
+
+  return new Promise<Response>((resolve, reject) => {
+    pendingRequests.set(requestId, { resolve, reject })
+
+    try {
+      const env = encryptPayload(payload)
+      ws!.send(encode(env))
+    } catch (e) {
+      pendingRequests.delete(requestId)
+      reject(e as Error)
+      return
+    }
+
+    const timer = setTimeout(() => {
+      if (pendingRequests.has(requestId)) {
+        pendingRequests.delete(requestId)
+        reject(new Error("Request timeout"))
+      }
+    }, 30000)
+    ;(timer as any).unref?.()
+  })
+}
+
+self.addEventListener("install", (event: ExtendableEvent) => {
+  // Take over immediately
+  event.waitUntil(self.skipWaiting())
+})
+
+self.addEventListener("activate", (event: ExtendableEvent) => {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener("fetch", (event: FetchEvent) => {
+  const { request } = event
+  const url = new URL(request.url)
+
+  // Only intercept same-origin, non-navigation, non-asset requests.
+  // We focus on programmatic fetch() calls (destination === "").
+  const isSameOrigin = url.origin === self.location.origin
+  const isProgrammatic = request.destination === ""
+  const isControlChannel = url.pathname.startsWith("/__ra__")
+
+  if (!isSameOrigin || !isProgrammatic || isControlChannel) {
+    return
+  }
+
+  event.respondWith(
+    (async () => {
+      try {
+        return await tunnelFetch(request)
+      } catch (err) {
+        // On failure, fall back to network
+        return fetch(request)
+      }
+    })(),
+  )
+})
+

--- a/packages/demo/vite.config.js
+++ b/packages/demo/vite.config.js
@@ -7,4 +7,12 @@ export default defineConfig({
   define: {
     "process.env": JSON.stringify({}),
   },
+  build: {
+    rollupOptions: {
+      input: {
+        main: "index.html",
+        "tunnel-sw": "src/sw/tunnel-sw.ts",
+      },
+    },
+  },
 })


### PR DESCRIPTION
Adds a ServiceWorker to tunnel same-origin `fetch()` requests over the encrypted connection, allowing regular HTTP requests to optionally use the secure tunnel.

---
<a href="https://cursor.com/background-agent?bcId=bc-dd88d1b7-47f2-484d-9337-2718b9c9c0d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dd88d1b7-47f2-484d-9337-2718b9c9c0d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

