### PR TITLE
Intercept and tunnel non-tunneled requests

### DIFF
--- a/packages/demo/public/ra-sw.js
+++ b/packages/demo/public/ra-sw.js
@@ -1,0 +1,182 @@
+// ra-sw.js - Service Worker that intercepts same-origin HTTP requests
+// and forwards them to the page via BroadcastChannel for tunneling.
+
+// Configuration can be prepended here if needed, e.g.:
+// self.RA_HTTPS_SW_CONFIG = { baseUrl: "https://example.com" }
+
+// Immediately take control on install/activate
+self.addEventListener('install', (event) => {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim())
+})
+
+// Create a single BroadcastChannel for request/response exchange
+const CHANNEL_NAME = 'ra-https-tunnel'
+let bc
+
+function getBroadcastChannel() {
+  if (!bc) {
+    try {
+      bc = new BroadcastChannel(CHANNEL_NAME)
+    } catch (e) {
+      // BroadcastChannel not available; leave undefined to trigger network fallback
+      bc = null
+    }
+  }
+  return bc
+}
+
+function isSameOrigin(urlString) {
+  try {
+    const u = new URL(urlString)
+    return u.origin === self.location.origin
+  } catch {
+    return false
+  }
+}
+
+function shouldBypass(request) {
+  try {
+    const url = new URL(request.url)
+    // Bypass navigation/document requests to avoid breaking app shell
+    if (request.mode === 'navigate') return true
+    // Only intercept programmatic fetch() calls (destination is empty string)
+    if (request.destination && request.destination !== '') return true
+    // Bypass the service worker script itself and RA control channel
+    if (url.pathname === '/ra-sw.js' || url.pathname.startsWith('/__ra__')) return true
+    // Only handle http(s) same-origin requests
+    if (!isSameOrigin(request.url)) return true
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return true
+    return false
+  } catch {
+    return true
+  }
+}
+
+async function readBodyAsString(request) {
+  // Only attempt to read body for methods that usually have one
+  const method = (request.method || 'GET').toUpperCase()
+  if (method === 'GET' || method === 'HEAD') return undefined
+  try {
+    // Prefer text; this demo focuses on JSON/text payloads
+    return await request.text()
+  } catch {
+    // Fallback to ArrayBuffer -> UTF-8 decode
+    try {
+      const ab = await request.arrayBuffer()
+      return new TextDecoder().decode(ab)
+    } catch {
+      return undefined
+    }
+  }
+}
+
+function headersToObject(headers) {
+  const out = {}
+  try {
+    for (const [k, v] of headers.entries()) {
+      out[k] = v
+    }
+  } catch {}
+  return out
+}
+
+function objectToHeaders(obj) {
+  const headers = new Headers()
+  if (obj && typeof obj === 'object') {
+    for (const k of Object.keys(obj)) {
+      try { headers.append(k, obj[k]) } catch {}
+    }
+  }
+  return headers
+}
+
+function timeout(ms) {
+  return new Promise((_, reject) => {
+    const t = setTimeout(() => {
+      clearTimeout(t)
+      reject(new Error('SW tunnel timeout'))
+    }, ms)
+    // no unref in browser
+  })
+}
+
+async function tunnelFetchThroughPage(request) {
+  const channel = getBroadcastChannel()
+  if (!channel) throw new Error('BroadcastChannel unavailable')
+
+  const correlationId = Math.random().toString(36).slice(2)
+  const reqUrl = request.url
+  const method = request.method || 'GET'
+  const headers = headersToObject(request.headers)
+  const body = await readBodyAsString(request)
+
+  const responsePromise = new Promise((resolve, reject) => {
+    const onMessage = (evt) => {
+      const data = evt && evt.data
+      if (!data || data.type !== 'http_response' || data.id !== correlationId) return
+      channel.removeEventListener('message', onMessage)
+      if (data.error) {
+        reject(new Error(data.error))
+        return
+      }
+      try {
+        const respHeaders = objectToHeaders(data.headers || {})
+        const responseInit = {
+          status: data.status || 200,
+          statusText: data.statusText || '',
+          headers: respHeaders,
+        }
+        const respBody = typeof data.body === 'string' ? data.body : ''
+        resolve(new Response(respBody, responseInit))
+      } catch (e) {
+        reject(e)
+      }
+    }
+    channel.addEventListener('message', onMessage)
+  })
+
+  // Send the request to any listening page script
+  try {
+    channel.postMessage({
+      type: 'http_request',
+      id: correlationId,
+      url: reqUrl,
+      method,
+      headers,
+      body,
+    })
+  } catch (e) {
+    throw e
+  }
+
+  // Race with timeout; fallback handled by caller
+  const result = await Promise.race([responsePromise, timeout(30000)])
+  return result
+}
+
+self.addEventListener('fetch', (event) => {
+  const request = event.request
+  if (shouldBypass(request)) return
+
+  event.respondWith((async () => {
+    try {
+      const response = await tunnelFetchThroughPage(request)
+      if (response) return response
+      // If no response (unexpected), fall through to network
+      return fetch(request)
+    } catch (e) {
+      // On any error, fallback to network
+      try {
+        return await fetch(request)
+      } catch (err) {
+        // If even network fails, return a generic 502
+        return new Response('ServiceWorker tunnel error', { status: 502 })
+      }
+    }
+  })())
+})
+

--- a/packages/demo/server/server.ts
+++ b/packages/demo/server/server.ts
@@ -23,6 +23,7 @@ let messages: Message[] = []
 let totalMessageCount = 0
 const MAX_MESSAGES = 30
 const startTime = Date.now()
+let testCounter = 0
 
 // API Routes
 app.get("/uptime", (_req, res) => {
@@ -42,6 +43,12 @@ app.get("/uptime", (_req, res) => {
       }s`,
     },
   })
+})
+
+// Test endpoint: increment a counter
+app.post("/increment", (_req, res) => {
+  testCounter += 1
+  res.json({ counter: testCounter })
 })
 
 wss.on("connection", (ws: WebSocket) => {

--- a/packages/demo/src/App.tsx
+++ b/packages/demo/src/App.tsx
@@ -37,6 +37,7 @@ function App() {
   const [username] = useState<string>(getStoredUsername)
   const [connected, setConnected] = useState<boolean>(false)
   const [uptime, setUptime] = useState<string>("")
+  const [panelOutput, setPanelOutput] = useState<string>("")
   const [hiddenMessagesCount, setHiddenMessagesCount] = useState<number>(0)
   const [verifyResult, setVerifyResult] = useState<string>("")
   const wsRef = useRef<WebSocket | null>(null)
@@ -155,6 +156,32 @@ function App() {
     })
   }
 
+  // Test panel actions using native fetch without initializing a new tunnel
+  const testGetUptime = useCallback(async () => {
+    try {
+      const res = await fetch("/uptime", { credentials: "same-origin" })
+      const text = await res.text()
+      setPanelOutput(`GET /uptime -> ${res.status}: ${text}`)
+    } catch (e: any) {
+      setPanelOutput(`GET /uptime error: ${e?.message || e}`)
+    }
+  }, [])
+
+  const testPostIncrement = useCallback(async () => {
+    try {
+      const res = await fetch("/increment", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+        credentials: "same-origin",
+      })
+      const text = await res.text()
+      setPanelOutput(`POST /increment -> ${res.status}: ${text}`)
+    } catch (e: any) {
+      setPanelOutput(`POST /increment error: ${e?.message || e}`)
+    }
+  }, [])
+
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     setNewMessage(e.target.value)
   }
@@ -220,6 +247,16 @@ function App() {
       </div>
 
       <div className="messages-container">
+        <div className="uptime-display" style={{ marginBottom: "10px" }}>
+          <strong>Service Worker Test Panel</strong>
+          <div style={{ display: "flex", gap: 8, marginTop: 6, flexWrap: "wrap" }}>
+            <button onClick={testGetUptime} style={{ padding: "4px 8px", fontSize: "0.85em" }}>GET /uptime (native)</button>
+            <button onClick={testPostIncrement} style={{ padding: "4px 8px", fontSize: "0.85em" }}>POST /increment (native)</button>
+          </div>
+          {panelOutput && (
+            <pre style={{ whiteSpace: "pre-wrap", background: "#f5f5f5", padding: 8, borderRadius: 4, marginTop: 6 }}>{panelOutput}</pre>
+          )}
+        </div>
         {uptime && (
           <div className="uptime-display">
             Server uptime: {uptime}{" "}

--- a/packages/demo/src/main.tsx
+++ b/packages/demo/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react"
 import { createRoot } from "react-dom/client"
 import "./index.css"
 import App from "./App.js"
+import "./ra-sw-broker.js"
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/packages/demo/src/ra-sw-broker.ts
+++ b/packages/demo/src/ra-sw-broker.ts
@@ -1,0 +1,101 @@
+import { TunnelClient } from "ra-https-tunnel"
+
+// Register the Service Worker as early as possible
+if (typeof navigator !== "undefined" && "serviceWorker" in navigator) {
+  // Use root scope so all same-origin requests are intercepted
+  navigator.serviceWorker
+    .register("/ra-sw.js", { scope: "/" })
+    .then((reg) => {
+      // Optionally log
+      // console.log("RA SW registered:", reg.scope)
+    })
+    .catch((err) => {
+      console.error("Failed to register RA SW:", err)
+    })
+}
+
+// Page-side broker to service SW fetches via the encrypted tunnel
+const CHANNEL_NAME = "ra-https-tunnel"
+const bc = typeof BroadcastChannel !== "undefined" ? new BroadcastChannel(CHANNEL_NAME) : null
+
+// Compute base URL for the tunnel server (mirrors App.tsx logic)
+const baseUrl =
+  typeof document !== "undefined" && document.location.hostname === "localhost"
+    ? "http://localhost:3001"
+    : "https://ra-https.up.railway.app"
+
+let tunnelPromise: Promise<TunnelClient> | null = null
+
+async function getTunnel(): Promise<TunnelClient> {
+  if (!tunnelPromise) {
+    tunnelPromise = TunnelClient.initialize(baseUrl, {
+      match: () => true,
+    })
+  }
+  return tunnelPromise
+}
+
+function normalizeHeaders(initHeaders: Record<string, string> | undefined): HeadersInit {
+  const headers: Record<string, string> = {}
+  if (initHeaders) {
+    for (const k of Object.keys(initHeaders)) headers[k] = String(initHeaders[k])
+  }
+  // Ensure cookies are forwarded for same-origin requests
+  try {
+    if (typeof document !== "undefined" && document.cookie) {
+      if (!("cookie" in headers)) headers["cookie"] = document.cookie
+    }
+  } catch {}
+  return headers
+}
+
+async function handleHttpRequestMessage(message: any) {
+  try {
+    const enc = await getTunnel()
+    const url: string = message.url
+    const method: string = message.method || "GET"
+    const headers: HeadersInit = normalizeHeaders(message.headers)
+    const body: BodyInit | undefined = typeof message.body === "string" ? message.body : undefined
+
+    // Important: use the encrypted tunnel fetch
+    const resp = await enc.fetch(url, {
+      method,
+      headers,
+      body,
+    })
+
+    const text = await resp.text()
+    const headersObj: Record<string, string> = {}
+    resp.headers.forEach((v, k) => (headersObj[k] = v))
+
+    bc?.postMessage({
+      type: "http_response",
+      id: message.id,
+      status: resp.status,
+      statusText: resp.statusText,
+      headers: headersObj,
+      body: text,
+    })
+  } catch (e: any) {
+    bc?.postMessage({
+      type: "http_response",
+      id: message.id,
+      status: 502,
+      statusText: "Bad Gateway",
+      headers: {},
+      body: "",
+      error: e?.message || String(e),
+    })
+  }
+}
+
+if (bc) {
+  bc.addEventListener("message", (evt) => {
+    const data = (evt && (evt as any).data) || null
+    if (!data) return
+    if (data.type === "http_request" && data.url) {
+      handleHttpRequestMessage(data)
+    }
+  })
+}
+


### PR DESCRIPTION
Add a Service Worker and page-side broker to transparently tunnel same-origin HTTP requests through the existing encrypted connection.

This enables the existing encrypted tunnel to automatically intercept and route standard browser `fetch()` requests, allowing applications to use native APIs while still benefiting from the secure tunnel. A new test panel demonstrates this functionality without altering existing demo behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-ceacbf65-a34a-47aa-96d0-ae8213854493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ceacbf65-a34a-47aa-96d0-ae8213854493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

