### PR TITLE
Create encrypted-only request decorator and test

### DIFF
--- a/packages/tunnel/src/encryptedOnly.ts
+++ b/packages/tunnel/src/encryptedOnly.ts
@@ -1,0 +1,50 @@
+import type { Request, Response, NextFunction } from "express"
+
+/**
+ * Unique symbol set on requests that arrive via the encrypted tunnel.
+ * This cannot be spoofed by external HTTP clients.
+ */
+export const RA_HTTPS_ENCRYPTED: unique symbol = Symbol.for(
+  "ra-https:encrypted",
+)
+
+/**
+ * Mark an Express `Request` as arriving via the encrypted tunnel.
+ */
+export function markEncryptedRequest(req: unknown): void {
+  try {
+    ;(req as any)[RA_HTTPS_ENCRYPTED] = true
+  } catch {}
+}
+
+/**
+ * Check whether a request arrived via the encrypted tunnel.
+ */
+export function isEncryptedRequest(req: unknown): boolean {
+  try {
+    return Boolean((req as any)?.[RA_HTTPS_ENCRYPTED] === true)
+  } catch {
+    return false
+  }
+}
+
+export type EncryptedOnlyOptions = {
+  /** HTTP status code to return when access is denied (default 403). */
+  statusCode?: number
+  /** Message body to return when access is denied. */
+  errorMessage?: string
+}
+
+/**
+ * Express middleware that restricts access to requests delivered via the
+ * encrypted tunnel only. Direct HTTP requests will be rejected.
+ */
+export function encryptedOnly(options?: EncryptedOnlyOptions) {
+  const status = options?.statusCode ?? 403
+  const message = options?.errorMessage ?? "Encrypted channel required"
+  return function (_req: Request, res: Response, next: NextFunction) {
+    if (isEncryptedRequest(_req)) return next()
+    res.status(status).send(message)
+  }
+}
+

--- a/packages/tunnel/src/index.ts
+++ b/packages/tunnel/src/index.ts
@@ -6,3 +6,9 @@ export {
   ServerRAMockWebSocketServer,
 } from "./ServerRAWebSocket.js"
 export { ClientRAMockWebSocket } from "./ClientRAWebSocket.js"
+export {
+  encryptedOnly,
+  isEncryptedRequest,
+  markEncryptedRequest,
+  RA_HTTPS_ENCRYPTED,
+} from "./encryptedOnly.js"

--- a/packages/tunnel/src/server.ts
+++ b/packages/tunnel/src/server.ts
@@ -30,6 +30,7 @@ import {
   sanitizeHeaders,
   getStatusText,
 } from "./utils/server.js"
+import { markEncryptedRequest } from "./encryptedOnly.js"
 import {
   ServerRAMockWebSocket,
   ServerRAMockWebSocketServer,
@@ -363,6 +364,10 @@ export class TunnelServer {
       })
 
       // Execute the request against the Express app
+      // Tag this request as arriving via the encrypted tunnel
+      try {
+        markEncryptedRequest(req)
+      } catch {}
       this.app(req, res)
     } catch (error) {
       const errorResponse: RAEncryptedHTTPResponse = {

--- a/packages/tunnel/test/encryptedOnly.test.ts
+++ b/packages/tunnel/test/encryptedOnly.test.ts
@@ -1,0 +1,54 @@
+import test from "ava"
+import express from "express"
+import type { AddressInfo } from "node:net"
+
+import { TunnelClient, TunnelServer, encryptedOnly } from "ra-https-tunnel"
+import { parseTdxQuote, hex } from "ra-https-qvl"
+import { loadQuote } from "./helpers/helpers.js" 
+
+test.serial("encryptedOnly blocks direct HTTP and allows tunneled requests", async (t) => {
+  const app = express()
+
+  app.get("/public", (_req, res) => res.status(200).send("ok"))
+  app.get("/secret", encryptedOnly(), (_req, res) => res.status(200).send("shh"))
+
+  const quote = loadQuote({ tdxv4: true })
+  const tunnelServer = await TunnelServer.initialize(app, quote)
+
+  await new Promise<void>((resolve) => {
+    tunnelServer.server.listen(0, "127.0.0.1", () => resolve())
+  })
+  const address = tunnelServer.server.address() as AddressInfo
+  const origin = `http://127.0.0.1:${address.port}`
+
+  // Direct HTTP should work for public and be blocked for secret
+  const publicRes = await fetch(origin + "/public")
+  t.is(publicRes.status, 200)
+  t.is(await publicRes.text(), "ok")
+
+  const secretRes = await fetch(origin + "/secret")
+  t.is(secretRes.status, 403)
+
+  // Tunnel client should be allowed for secret
+  const quoteBodyParsed = parseTdxQuote(quote).body
+  const tunnelClient = await TunnelClient.initialize(origin, {
+    mrtd: hex(quoteBodyParsed.mr_td),
+    report_data: hex(quoteBodyParsed.report_data),
+  })
+  try {
+    const res = await tunnelClient.fetch("/secret")
+    t.is(res.status, 200)
+    t.is(await res.text(), "shh")
+  } finally {
+    try {
+      if (tunnelClient.ws) {
+        tunnelClient.ws.onclose = () => {}
+        tunnelClient.ws.close()
+      }
+    } catch {}
+  }
+
+  await new Promise<void>((resolve) => tunnelServer.wss.close(() => resolve()))
+  await new Promise<void>((resolve) => tunnelServer.server.close(() => resolve()))
+})
+


### PR DESCRIPTION
Add `encryptedOnly` Express middleware to restrict routes to the encrypted tunnel, ensuring direct HTTP requests are rejected.

---
<a href="https://cursor.com/background-agent?bcId=bc-309e24c4-3c4a-4556-9c8d-3bd415d46f78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-309e24c4-3c4a-4556-9c8d-3bd415d46f78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

