### PR TITLE
Create encrypted-only request decorator and test

### DIFF
--- a/packages/tunnel/src/express.ts
+++ b/packages/tunnel/src/express.ts
@@ -1,0 +1,44 @@
+import type { Request, RequestHandler } from "express"
+
+// Symbol used to mark requests that arrived via the encrypted tunnel
+export const ENCRYPTED_REQUEST = Symbol.for("ra-https:encrypted_request")
+
+export function isEncryptedRequest(req: Request | any): boolean {
+  try {
+    return Boolean(req && req[ENCRYPTED_REQUEST] === true)
+  } catch {
+    return false
+  }
+}
+
+export function markRequestAsEncrypted(req: any): void {
+  try {
+    req[ENCRYPTED_REQUEST] = true
+  } catch {}
+}
+
+/**
+ * Express middleware to require that a request was delivered over the
+ * encrypted tunnel. Direct HTTP access will be rejected.
+ */
+export function encryptedOnly(options?: {
+  status?: number
+  message?: string
+}): RequestHandler {
+  const status = options?.status ?? 403
+  const message = options?.message ?? "Encrypted channel required"
+  return (req, res, next) => {
+    if (isEncryptedRequest(req)) {
+      return next()
+    }
+    try {
+      res.status(status).type("text/plain").send(message)
+    } catch {
+      // In case headers are already sent or similar, end the response
+      try {
+        res.end()
+      } catch {}
+    }
+  }
+}
+

--- a/packages/tunnel/src/index.ts
+++ b/packages/tunnel/src/index.ts
@@ -6,3 +6,8 @@ export {
   ServerRAMockWebSocketServer,
 } from "./ServerRAWebSocket.js"
 export { ClientRAMockWebSocket } from "./ClientRAWebSocket.js"
+export {
+  encryptedOnly,
+  isEncryptedRequest,
+  ENCRYPTED_REQUEST,
+} from "./express.js"

--- a/packages/tunnel/src/server.ts
+++ b/packages/tunnel/src/server.ts
@@ -30,6 +30,7 @@ import {
   sanitizeHeaders,
   getStatusText,
 } from "./utils/server.js"
+import { markRequestAsEncrypted } from "./express.js"
 import {
   ServerRAMockWebSocket,
   ServerRAMockWebSocketServer,
@@ -363,6 +364,10 @@ export class TunnelServer {
       })
 
       // Execute the request against the Express app
+      // Mark this synthetic request as arriving via the encrypted tunnel
+      try {
+        markRequestAsEncrypted(req)
+      } catch {}
       this.app(req, res)
     } catch (error) {
       const errorResponse: RAEncryptedHTTPResponse = {

--- a/packages/tunnel/test/encryptedOnly.test.ts
+++ b/packages/tunnel/test/encryptedOnly.test.ts
@@ -1,0 +1,48 @@
+import test from "ava"
+import express from "express"
+import type { AddressInfo } from "node:net"
+
+import { TunnelClient, TunnelServer, encryptedOnly } from "ra-https-tunnel"
+import { loadQuote } from "./helpers/helpers.js"
+
+test.serial("encryptedOnly blocks direct HTTP but allows tunneled", async (t) => {
+  const app = express()
+  app.get("/secret", encryptedOnly(), (_req, res) => {
+    res.status(200).send("shh")
+  })
+
+  const quote = loadQuote({ tdxv4: true })
+  const tunnelServer = await TunnelServer.initialize(app, quote)
+  await new Promise<void>((resolve) => {
+    tunnelServer.server.listen(0, "127.0.0.1", () => resolve())
+  })
+  const address = tunnelServer.server.address() as AddressInfo
+  const origin = `http://127.0.0.1:${address.port}`
+
+  // Direct HTTP should be forbidden
+  const direct = await fetch(origin + "/secret")
+  t.is(direct.status, 403)
+
+  // Tunnel request should succeed
+  const tunnelClient = await TunnelClient.initialize(origin, {
+    // In these tests, the helper-generated quote will be accepted by default client verification
+    match: () => true,
+  })
+  try {
+    const res = await tunnelClient.fetch("/secret")
+    t.is(res.status, 200)
+    t.is(await res.text(), "shh")
+  } finally {
+    try {
+      if (tunnelClient.ws) tunnelClient.ws.close()
+    } catch {}
+  }
+
+  await new Promise<void>((resolve) => {
+    tunnelServer.wss.close(() => resolve())
+  })
+  await new Promise<void>((resolve) => {
+    tunnelServer.server.close(() => resolve())
+  })
+})
+


### PR DESCRIPTION
Add `encryptedOnly` Express middleware to restrict routes to encrypted tunnel access only.

---
<a href="https://cursor.com/background-agent?bcId=bc-51e8cb2c-d417-420f-8d58-07bcd39370b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-51e8cb2c-d417-420f-8d58-07bcd39370b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

