### PR TITLE
Move and test x25519 helpers

### DIFF
--- a/packages/qvl/src/index.ts
+++ b/packages/qvl/src/index.ts
@@ -2,6 +2,7 @@ export * from "./formatters.js"
 export * from "./structs.js"
 export * from "./x509.js"
 export * from "./utils.js"
+export { getX25519ExpectedReportData, isX25519Bound } from "./utils.js"
 
 export * from "./verifyTdx.js"
 export * from "./verifySgx.js"

--- a/packages/tunnel/src/client.ts
+++ b/packages/tunnel/src/client.ts
@@ -7,6 +7,8 @@ import {
   TdxQuote,
   verifySgx,
   verifyTdx,
+  getX25519ExpectedReportData as qvlGetX25519ExpectedReportData,
+  isX25519Bound as qvlIsX25519Bound,
 } from "ra-https-qvl"
 import { base64 as scureBase64 } from "@scure/base"
 import { concatUint8Arrays, areUint8ArraysEqual } from "uint8array-extras"
@@ -642,10 +644,11 @@ export class TunnelClient {
     if (!issuedAt) throw new Error("missing verifier_nonce.iat")
     if (!this.serverX25519PublicKey) throw new Error("missing x25519 key")
 
-    const userdata = this.serverX25519PublicKey
-    const buf = concatUint8Arrays([nonce, issuedAt, userdata])
-    const expectedReport = await crypto.subtle.digest("SHA-512", buf)
-    return new Uint8Array(expectedReport)
+    return await qvlGetX25519ExpectedReportData(
+      nonce,
+      issuedAt,
+      this.serverX25519PublicKey,
+    )
   }
 
   /**
@@ -654,8 +657,17 @@ export class TunnelClient {
    * to verify that we have a secure connection.
    */
   async isX25519Bound(quote: TdxQuote | SgxQuote): Promise<boolean> {
-    const actualReport = quote.body.report_data
-    const expectedReport = await this.getX25519ExpectedReportData()
-    return areUint8ArraysEqual(actualReport, expectedReport)
+    const nonce = this.reportBindingData?.verifierData?.val
+    const issuedAt = this.reportBindingData?.verifierData?.iat
+    if (!nonce) throw new Error("missing verifier_nonce.val")
+    if (!issuedAt) throw new Error("missing verifier_nonce.iat")
+    if (!this.serverX25519PublicKey) throw new Error("missing x25519 key")
+
+    return await qvlIsX25519Bound(
+      quote,
+      nonce,
+      issuedAt,
+      this.serverX25519PublicKey,
+    )
   }
 }


### PR DESCRIPTION
Move X25519 report binding helpers to QVL and add a test using GCP verifier_nonce fields.

This centralizes reusable X25519 binding logic in the QVL package, simplifying the Tunnel client and ensuring the helpers are validated with real-world GCP attestation data.

---
<a href="https://cursor.com/background-agent?bcId=bc-549fd05f-e40e-4d49-b79c-664a1c2574a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-549fd05f-e40e-4d49-b79c-664a1c2574a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

