### PR TITLE
Test fmspc freshness with tcb caching

### DIFF
--- a/packages/qvl/test/qvl-tcb.test.ts
+++ b/packages/qvl/test/qvl-tcb.test.ts
@@ -1,0 +1,262 @@
+// @ts-nocheck
+import test from "ava"
+import fs from "node:fs"
+import path from "node:path"
+import {
+  verifySgx,
+  parseSgxQuote,
+  isSgxQuote,
+  QV_X509Certificate,
+} from "ra-https-qvl"
+import { extractPemCertificates } from "ra-https-qvl/utils"
+
+const BASE_TIME = Date.parse("2025-09-01")
+const SAMPLE_DIR = "test/sample/sgx"
+
+type IntelTcbInfo = {
+  tcbInfo: {
+    version: number
+    issueDate: string
+    nextUpdate: string
+    fmspc: string
+    pceId: string
+    tcbType: number
+    tcbEvaluationDataNumber: number
+    tcbLevels: Array<{
+      tcb: { [k: string]: number }
+      tcbDate: string
+      tcbStatus:
+        | "UpToDate"
+        | "OutOfDate"
+        | "OutOfDateConfigurationNeeded"
+        | "ConfigurationNeeded"
+        | "Revoked"
+        | string
+    }>
+  }
+  signature?: string
+}
+
+async function fetchAndCacheTcbInfo(fmspcHex: string): Promise<IntelTcbInfo> {
+  const fmspc = fmspcHex.toLowerCase()
+  const cachePath = path.join(SAMPLE_DIR, `tcbInfo-${fmspc}.json`)
+
+  // Return from cache when present
+  if (fs.existsSync(cachePath)) {
+    const raw = fs.readFileSync(cachePath, "utf8")
+    return JSON.parse(raw)
+  }
+
+  const url = `https://api.trustedservices.intel.com/sgx/certification/v4/tcb?fmspc=${fmspc}`
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+  }
+  // Optional API key if available in environment
+  const key =
+    process.env.INTEL_SGX_API_KEY ||
+    process.env.INTEL_API_KEY ||
+    process.env.OCP_APIM_SUBSCRIPTION_KEY
+  if (key) headers["Ocp-Apim-Subscription-Key"] = key
+
+  const resp = await fetch(url, { headers })
+  if (!resp.ok) {
+    throw new Error(
+      `Failed to fetch TCB info for FMSPC=${fmspc}: ${resp.status} ${resp.statusText}`,
+    )
+  }
+  const data = (await resp.json()) as IntelTcbInfo
+
+  // Ensure samples directory exists and write cache
+  fs.mkdirSync(SAMPLE_DIR, { recursive: true })
+  fs.writeFileSync(cachePath, JSON.stringify(data, null, 2))
+  return data
+}
+
+function parseCpuSvn(quoteBytes: Uint8Array): number[] {
+  const { body } = parseSgxQuote(quoteBytes)
+  return Array.from(body.cpu_svn)
+}
+
+function getPceSvn(quoteBytes: Uint8Array): number {
+  const { header } = parseSgxQuote(quoteBytes)
+  return header.pce_svn
+}
+
+function pickTcbStatusForSgx(
+  quoteBytes: Uint8Array,
+  info: IntelTcbInfo,
+): {
+  status: string
+  matchedLevelIndex: number
+  freshnessOk: boolean
+} {
+  const cpuSvn = parseCpuSvn(quoteBytes)
+  const pceSvn = getPceSvn(quoteBytes)
+
+  const tcbInfo = info.tcbInfo
+  const now = BASE_TIME
+  const freshnessOk =
+    Date.parse(tcbInfo.issueDate) <= now && now <= Date.parse(tcbInfo.nextUpdate)
+
+  // Iterate in provided order; Intel typically sorts from most secure to least
+  for (let i = 0; i < tcbInfo.tcbLevels.length; i++) {
+    const level = tcbInfo.tcbLevels[i]
+    const tcb = level.tcb
+
+    const pceOk = typeof tcb.pcesvn === "number" ? pceSvn >= tcb.pcesvn : true
+    // Compare each SGX component SVN if present
+    let cpuOk = true
+    for (let comp = 1; comp <= 16; comp++) {
+      const key = `sgxtcbcomp${String(comp).padStart(2, "0")}svn`
+      if (Object.prototype.hasOwnProperty.call(tcb, key)) {
+        const required = (tcb as any)[key] as number
+        if (cpuSvn[comp - 1] < required) {
+          cpuOk = false
+          break
+        }
+      }
+    }
+
+    if (cpuOk && pceOk) {
+      return { status: level.tcbStatus, matchedLevelIndex: i, freshnessOk }
+    }
+  }
+
+  // If no level matched, treat as OutOfDate
+  return { status: "OutOfDate", matchedLevelIndex: -1, freshnessOk }
+}
+
+function isAcceptableStatus(status: string): boolean {
+  return (
+    status === "UpToDate" ||
+    status === "ConfigurationNeeded" ||
+    status === "OutOfDateConfigurationNeeded"
+  )
+}
+
+// Builds a verifyFmspc callback that captures the evaluated state for assertions
+function buildVerifyFmspcHook(stateRef: { status?: string; freshnessOk?: boolean }) {
+  return async (fmspcHex: string, quote: unknown): Promise<boolean> => {
+    try {
+      if (!isSgxQuote(quote as any)) return false
+      const parsed = quote as any
+
+      // Fetch and evaluate
+      const tcbInfo = await fetchAndCacheTcbInfo(fmspcHex)
+      const cpuSvn = Array.from(parsed.body.cpu_svn as Uint8Array)
+      const pceSvn = parsed.header.pce_svn as number
+      const now = BASE_TIME
+      const freshnessOk =
+        Date.parse(tcbInfo.tcbInfo.issueDate) <= now &&
+        now <= Date.parse(tcbInfo.tcbInfo.nextUpdate)
+
+      let statusFound = "OutOfDate"
+      for (const level of tcbInfo.tcbInfo.tcbLevels) {
+        const tcb = level.tcb as any
+        const pceOk =
+          typeof tcb.pcesvn === "number" ? pceSvn >= tcb.pcesvn : true
+        let cpuOk = true
+        for (let comp = 1; comp <= 16; comp++) {
+          const key = `sgxtcbcomp${String(comp).padStart(2, "0")}svn`
+          if (Object.prototype.hasOwnProperty.call(tcb, key)) {
+            if (cpuSvn[comp - 1] < tcb[key]) {
+              cpuOk = false
+              break
+            }
+          }
+        }
+        if (cpuOk && pceOk) {
+          statusFound = level.tcbStatus
+          break
+        }
+      }
+
+      stateRef.status = statusFound
+      stateRef.freshnessOk = freshnessOk
+
+      // Accept only certain statuses and require freshness
+      return freshnessOk && isAcceptableStatus(statusFound)
+    } catch (e) {
+      // If TCB fetch fails (e.g., 404), treat as policy failure
+      stateRef.status = "Unavailable"
+      stateRef.freshnessOk = false
+      return false
+    }
+  }
+}
+
+function loadExtraCertsIfNeeded(samplePath: string): {
+  crls: Uint8Array[]
+  extraCertdata?: string[]
+  pinnedRoot?: QV_X509Certificate
+} {
+  if (samplePath.endsWith("test/sample/sgx/quote.dat")) {
+    const root = extractPemCertificates(
+      fs.readFileSync("test/sample/sgx/trustedRootCaCert.pem"),
+    )
+    const pckChain = extractPemCertificates(
+      fs.readFileSync("test/sample/sgx/pckSignChain.pem"),
+    )
+    const pckCert = extractPemCertificates(
+      fs.readFileSync("test/sample/sgx/pckCert.pem"),
+    )
+    const extraCertdata = [...root, ...pckChain, ...pckCert]
+    const crls = [
+      fs.readFileSync("test/sample/sgx/rootCaCrl.der"),
+      fs.readFileSync("test/sample/sgx/intermediateCaCrl.der"),
+    ]
+    return { crls, extraCertdata, pinnedRoot: new QV_X509Certificate(root[0]) }
+  }
+  return { crls: [] }
+}
+
+async function runSgxSample(t: any, sampleRelPath: string) {
+  const quote = fs.readFileSync(sampleRelPath)
+  const state: { status?: string; freshnessOk?: boolean } = {}
+  const verifyHook = buildVerifyFmspcHook(state)
+  const extras = loadExtraCertsIfNeeded(sampleRelPath)
+
+  try {
+    const ok = await verifySgx(quote, {
+      date: BASE_TIME,
+      crls: extras.crls,
+      extraCertdata: extras.extraCertdata,
+      pinnedRootCerts: extras.pinnedRoot ? [extras.pinnedRoot] : undefined,
+      verifyFmspc: verifyHook,
+    })
+
+    // verifySgx succeeded: ensure our policy accepted the TCB status
+    t.true(ok)
+    t.truthy(state.status)
+    t.true(state!.freshnessOk === true)
+    t.true(isAcceptableStatus(state.status!))
+  } catch (err: any) {
+    // verifySgx rejected: ensure it is due to our verifyFmspc policy
+    t.regex(String(err?.message ?? ""), /TCB validation failed/i)
+    t.truthy(state.status)
+    // We rejected because of unacceptable status or staleness
+    const unacceptable = !state!.freshnessOk || !isAcceptableStatus(state.status!)
+    t.true(unacceptable)
+  }
+}
+
+test.serial("TCB eval via verifyFmspc: Intel sample quote.dat", async (t) => {
+  await runSgxSample(t, "test/sample/sgx/quote.dat")
+})
+
+test.serial("TCB eval via verifyFmspc: sgx-occlum.dat", async (t) => {
+  await runSgxSample(t, "test/sample/sgx-occlum.dat")
+})
+
+test.serial("TCB eval via verifyFmspc: sgx-chinenyeokafor.dat", async (t) => {
+  await runSgxSample(t, "test/sample/sgx-chinenyeokafor.dat")
+})
+
+test.serial("TCB eval via verifyFmspc: sgx-tlsn-quote9.dat", async (t) => {
+  await runSgxSample(t, "test/sample/sgx-tlsn-quote9.dat")
+})
+
+test.serial("TCB eval via verifyFmspc: sgx-tlsn-quotedev.dat", async (t) => {
+  await runSgxSample(t, "test/sample/sgx-tlsn-quotedev.dat")
+})
+

--- a/packages/qvl/test/sample/sgx/tcbInfo-00906ed50000.json
+++ b/packages/qvl/test/sample/sgx/tcbInfo-00906ed50000.json
@@ -1,0 +1,1325 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 3,
+    "issueDate": "2025-09-28T05:52:19Z",
+    "nextUpdate": "2025-10-28T05:52:19Z",
+    "fmspc": "00906ed50000",
+    "pceId": "0000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber": 17,
+    "tcbLevels": [
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 21
+            },
+            {
+              "svn": 21
+            },
+            {
+              "svn": 2
+            },
+            {
+              "svn": 4
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 128
+            },
+            {
+              "svn": 14
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 13
+        },
+        "tcbDate": "2024-03-13T00:00:00Z",
+        "tcbStatus": "SWHardeningNeeded",
+        "advisoryIDs": [
+          "INTEL-SA-00334",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 21
+            },
+            {
+              "svn": 21
+            },
+            {
+              "svn": 2
+            },
+            {
+              "svn": 4
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 128
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 13
+        },
+        "tcbDate": "2024-03-13T00:00:00Z",
+        "tcbStatus": "ConfigurationAndSWHardeningNeeded",
+        "advisoryIDs": [
+          "INTEL-SA-00219",
+          "INTEL-SA-00289",
+          "INTEL-SA-00334",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 20
+            },
+            {
+              "svn": 20
+            },
+            {
+              "svn": 2
+            },
+            {
+              "svn": 4
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 128
+            },
+            {
+              "svn": 14
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 13
+        },
+        "tcbDate": "2023-02-15T00:00:00Z",
+        "tcbStatus": "OutOfDate",
+        "advisoryIDs": [
+          "INTEL-SA-00828",
+          "INTEL-SA-00219",
+          "INTEL-SA-00289",
+          "INTEL-SA-00334",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 20
+            },
+            {
+              "svn": 20
+            },
+            {
+              "svn": 2
+            },
+            {
+              "svn": 4
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 128
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 13
+        },
+        "tcbDate": "2023-02-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded",
+        "advisoryIDs": [
+          "INTEL-SA-00219",
+          "INTEL-SA-00289",
+          "INTEL-SA-00828",
+          "INTEL-SA-00334",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 19
+            },
+            {
+              "svn": 19
+            },
+            {
+              "svn": 2
+            },
+            {
+              "svn": 4
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 128
+            },
+            {
+              "svn": 6
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 13
+        },
+        "tcbDate": "2021-11-10T00:00:00Z",
+        "tcbStatus": "OutOfDate",
+        "advisoryIDs": [
+          "INTEL-SA-00614",
+          "INTEL-SA-00617",
+          "INTEL-SA-00219",
+          "INTEL-SA-00289",
+          "INTEL-SA-00828",
+          "INTEL-SA-00334",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 19
+            },
+            {
+              "svn": 19
+            },
+            {
+              "svn": 2
+            },
+            {
+              "svn": 4
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 128
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 13
+        },
+        "tcbDate": "2021-11-10T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded",
+        "advisoryIDs": [
+          "INTEL-SA-00161",
+          "INTEL-SA-00614",
+          "INTEL-SA-00617",
+          "INTEL-SA-00219",
+          "INTEL-SA-00289",
+          "INTEL-SA-00828",
+          "INTEL-SA-00334",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 17
+            },
+            {
+              "svn": 17
+            },
+            {
+              "svn": 2
+            },
+            {
+              "svn": 4
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 128
+            },
+            {
+              "svn": 6
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 11
+        },
+        "tcbDate": "2021-11-10T00:00:00Z",
+        "tcbStatus": "OutOfDate",
+        "advisoryIDs": [
+          "INTEL-SA-00614",
+          "INTEL-SA-00617",
+          "INTEL-SA-00161",
+          "INTEL-SA-00219",
+          "INTEL-SA-00289",
+          "INTEL-SA-00828",
+          "INTEL-SA-00334",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 17
+            },
+            {
+              "svn": 17
+            },
+            {
+              "svn": 2
+            },
+            {
+              "svn": 4
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 128
+            },
+            {
+              "svn": 6
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 10
+        },
+        "tcbDate": "2020-11-11T00:00:00Z",
+        "tcbStatus": "OutOfDate",
+        "advisoryIDs": [
+          "INTEL-SA-00161",
+          "INTEL-SA-00614",
+          "INTEL-SA-00617",
+          "INTEL-SA-00219",
+          "INTEL-SA-00289",
+          "INTEL-SA-00828",
+          "INTEL-SA-00334",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 17
+            },
+            {
+              "svn": 17
+            },
+            {
+              "svn": 2
+            },
+            {
+              "svn": 4
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 128
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 11
+        },
+        "tcbDate": "2021-11-10T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded",
+        "advisoryIDs": [
+          "INTEL-SA-00161",
+          "INTEL-SA-00614",
+          "INTEL-SA-00617",
+          "INTEL-SA-00219",
+          "INTEL-SA-00289",
+          "INTEL-SA-00828",
+          "INTEL-SA-00334",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 17
+            },
+            {
+              "svn": 17
+            },
+            {
+              "svn": 2
+            },
+            {
+              "svn": 4
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 128
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 10
+        },
+        "tcbDate": "2020-11-11T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded",
+        "advisoryIDs": [
+          "INTEL-SA-00477",
+          "INTEL-SA-00161",
+          "INTEL-SA-00614",
+          "INTEL-SA-00617",
+          "INTEL-SA-00219",
+          "INTEL-SA-00289",
+          "INTEL-SA-00828",
+          "INTEL-SA-00334",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 15
+            },
+            {
+              "svn": 15
+            },
+            {
+              "svn": 2
+            },
+            {
+              "svn": 4
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 128
+            },
+            {
+              "svn": 6
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 10
+        },
+        "tcbDate": "2020-06-10T00:00:00Z",
+        "tcbStatus": "OutOfDate",
+        "advisoryIDs": [
+          "INTEL-SA-00381",
+          "INTEL-SA-00389",
+          "INTEL-SA-00477",
+          "INTEL-SA-00161",
+          "INTEL-SA-00614",
+          "INTEL-SA-00617",
+          "INTEL-SA-00219",
+          "INTEL-SA-00289",
+          "INTEL-SA-00828",
+          "INTEL-SA-00334",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 15
+            },
+            {
+              "svn": 15
+            },
+            {
+              "svn": 2
+            },
+            {
+              "svn": 4
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 128
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 10
+        },
+        "tcbDate": "2020-06-10T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded",
+        "advisoryIDs": [
+          "INTEL-SA-00161",
+          "INTEL-SA-00381",
+          "INTEL-SA-00389",
+          "INTEL-SA-00477",
+          "INTEL-SA-00614",
+          "INTEL-SA-00617",
+          "INTEL-SA-00219",
+          "INTEL-SA-00289",
+          "INTEL-SA-00828",
+          "INTEL-SA-00334",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 14
+            },
+            {
+              "svn": 14
+            },
+            {
+              "svn": 2
+            },
+            {
+              "svn": 4
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 128
+            },
+            {
+              "svn": 6
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 10
+        },
+        "tcbDate": "2019-12-11T00:00:00Z",
+        "tcbStatus": "OutOfDate",
+        "advisoryIDs": [
+          "INTEL-SA-00320",
+          "INTEL-SA-00329",
+          "INTEL-SA-00161",
+          "INTEL-SA-00381",
+          "INTEL-SA-00389",
+          "INTEL-SA-00477",
+          "INTEL-SA-00614",
+          "INTEL-SA-00617",
+          "INTEL-SA-00219",
+          "INTEL-SA-00289",
+          "INTEL-SA-00828",
+          "INTEL-SA-00334",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 14
+            },
+            {
+              "svn": 14
+            },
+            {
+              "svn": 2
+            },
+            {
+              "svn": 4
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 128
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 10
+        },
+        "tcbDate": "2019-12-11T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded",
+        "advisoryIDs": [
+          "INTEL-SA-00161",
+          "INTEL-SA-00320",
+          "INTEL-SA-00329",
+          "INTEL-SA-00381",
+          "INTEL-SA-00389",
+          "INTEL-SA-00477",
+          "INTEL-SA-00614",
+          "INTEL-SA-00617",
+          "INTEL-SA-00219",
+          "INTEL-SA-00289",
+          "INTEL-SA-00828",
+          "INTEL-SA-00334",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 13
+            },
+            {
+              "svn": 13
+            },
+            {
+              "svn": 2
+            },
+            {
+              "svn": 4
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 128
+            },
+            {
+              "svn": 2
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 9
+        },
+        "tcbDate": "2019-11-13T00:00:00Z",
+        "tcbStatus": "OutOfDate",
+        "advisoryIDs": [
+          "INTEL-SA-00161",
+          "INTEL-SA-00320",
+          "INTEL-SA-00329",
+          "INTEL-SA-00381",
+          "INTEL-SA-00389",
+          "INTEL-SA-00477",
+          "INTEL-SA-00614",
+          "INTEL-SA-00617",
+          "INTEL-SA-00219",
+          "INTEL-SA-00289",
+          "INTEL-SA-00828",
+          "INTEL-SA-00334",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 13
+            },
+            {
+              "svn": 13
+            },
+            {
+              "svn": 2
+            },
+            {
+              "svn": 4
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 128
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 9
+        },
+        "tcbDate": "2019-11-13T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded",
+        "advisoryIDs": [
+          "INTEL-SA-00219",
+          "INTEL-SA-00161",
+          "INTEL-SA-00320",
+          "INTEL-SA-00329",
+          "INTEL-SA-00381",
+          "INTEL-SA-00389",
+          "INTEL-SA-00477",
+          "INTEL-SA-00614",
+          "INTEL-SA-00617",
+          "INTEL-SA-00289",
+          "INTEL-SA-00828",
+          "INTEL-SA-00334",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 2
+            },
+            {
+              "svn": 2
+            },
+            {
+              "svn": 2
+            },
+            {
+              "svn": 4
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 128
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 7
+        },
+        "tcbDate": "2019-05-15T00:00:00Z",
+        "tcbStatus": "OutOfDate",
+        "advisoryIDs": [
+          "INTEL-SA-00220",
+          "INTEL-SA-00270",
+          "INTEL-SA-00293",
+          "INTEL-SA-00219",
+          "INTEL-SA-00161",
+          "INTEL-SA-00320",
+          "INTEL-SA-00329",
+          "INTEL-SA-00381",
+          "INTEL-SA-00389",
+          "INTEL-SA-00477",
+          "INTEL-SA-00614",
+          "INTEL-SA-00617",
+          "INTEL-SA-00289",
+          "INTEL-SA-00828",
+          "INTEL-SA-00334",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 1
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 2
+            },
+            {
+              "svn": 4
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 128
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 7
+        },
+        "tcbDate": "2019-01-09T00:00:00Z",
+        "tcbStatus": "OutOfDate",
+        "advisoryIDs": [
+          "INTEL-SA-00233",
+          "INTEL-SA-00220",
+          "INTEL-SA-00270",
+          "INTEL-SA-00293",
+          "INTEL-SA-00219",
+          "INTEL-SA-00161",
+          "INTEL-SA-00320",
+          "INTEL-SA-00329",
+          "INTEL-SA-00381",
+          "INTEL-SA-00389",
+          "INTEL-SA-00477",
+          "INTEL-SA-00614",
+          "INTEL-SA-00617",
+          "INTEL-SA-00289",
+          "INTEL-SA-00828",
+          "INTEL-SA-00334",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 1
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 2
+            },
+            {
+              "svn": 4
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 128
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 6
+        },
+        "tcbDate": "2018-08-15T00:00:00Z",
+        "tcbStatus": "OutOfDate",
+        "advisoryIDs": [
+          "INTEL-SA-00203",
+          "INTEL-SA-00233",
+          "INTEL-SA-00220",
+          "INTEL-SA-00270",
+          "INTEL-SA-00293",
+          "INTEL-SA-00219",
+          "INTEL-SA-00161",
+          "INTEL-SA-00320",
+          "INTEL-SA-00329",
+          "INTEL-SA-00381",
+          "INTEL-SA-00389",
+          "INTEL-SA-00477",
+          "INTEL-SA-00614",
+          "INTEL-SA-00617",
+          "INTEL-SA-00289",
+          "INTEL-SA-00828",
+          "INTEL-SA-00334",
+          "INTEL-SA-00615"
+        ]
+      }
+    ]
+  },
+  "signature": "ed106dd55d42570a44f6becbc36bf2532685c2e3307cbc32e3677f392c8d770b0d47d7eba39d7fdb474c098b2e938ad3e265618fdd7ddcb3f8fbe2683fb7a815"
+}

--- a/packages/qvl/test/sample/sgx/tcbInfo-30606a000000.json
+++ b/packages/qvl/test/sample/sgx/tcbInfo-30606a000000.json
@@ -1,0 +1,825 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 3,
+    "issueDate": "2025-09-28T06:06:22Z",
+    "nextUpdate": "2025-10-28T06:06:22Z",
+    "fmspc": "30606a000000",
+    "pceId": "0000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber": 17,
+    "tcbLevels": [
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 14,
+              "category": "BIOS",
+              "type": "Early Microcode Update"
+            },
+            {
+              "svn": 14,
+              "category": "OS/VMM",
+              "type": "SGX Late Microcode Update"
+            },
+            {
+              "svn": 3,
+              "category": "OS/VMM",
+              "type": "TXT SINIT"
+            },
+            {
+              "svn": 3,
+              "category": "BIOS"
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 13
+        },
+        "tcbDate": "2024-03-13T00:00:00Z",
+        "tcbStatus": "SWHardeningNeeded",
+        "advisoryIDs": [
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 14,
+              "category": "BIOS",
+              "type": "Early Microcode Update"
+            },
+            {
+              "svn": 14,
+              "category": "OS/VMM",
+              "type": "SGX Late Microcode Update"
+            },
+            {
+              "svn": 3,
+              "category": "OS/VMM",
+              "type": "TXT SINIT"
+            },
+            {
+              "svn": 3,
+              "category": "BIOS"
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 13
+        },
+        "tcbDate": "2024-03-13T00:00:00Z",
+        "tcbStatus": "ConfigurationAndSWHardeningNeeded",
+        "advisoryIDs": [
+          "INTEL-SA-00657",
+          "INTEL-SA-00767",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 12,
+              "category": "BIOS",
+              "type": "Early Microcode Update"
+            },
+            {
+              "svn": 12,
+              "category": "OS/VMM",
+              "type": "SGX Late Microcode Update"
+            },
+            {
+              "svn": 3,
+              "category": "OS/VMM",
+              "type": "TXT SINIT"
+            },
+            {
+              "svn": 3,
+              "category": "BIOS"
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 13
+        },
+        "tcbDate": "2023-08-09T00:00:00Z",
+        "tcbStatus": "OutOfDate",
+        "advisoryIDs": [
+          "INTEL-SA-00960",
+          "INTEL-SA-00657",
+          "INTEL-SA-00767",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 12,
+              "category": "BIOS",
+              "type": "Early Microcode Update"
+            },
+            {
+              "svn": 12,
+              "category": "OS/VMM",
+              "type": "SGX Late Microcode Update"
+            },
+            {
+              "svn": 3,
+              "category": "OS/VMM",
+              "type": "TXT SINIT"
+            },
+            {
+              "svn": 3,
+              "category": "BIOS"
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 13
+        },
+        "tcbDate": "2023-08-09T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded",
+        "advisoryIDs": [
+          "INTEL-SA-00657",
+          "INTEL-SA-00767",
+          "INTEL-SA-00960",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 11,
+              "category": "BIOS",
+              "type": "Early Microcode Update"
+            },
+            {
+              "svn": 11,
+              "category": "OS/VMM",
+              "type": "SGX Late Microcode Update"
+            },
+            {
+              "svn": 3,
+              "category": "OS/VMM",
+              "type": "TXT SINIT"
+            },
+            {
+              "svn": 3,
+              "category": "BIOS"
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 13
+        },
+        "tcbDate": "2023-02-15T00:00:00Z",
+        "tcbStatus": "OutOfDate",
+        "advisoryIDs": [
+          "INTEL-SA-00828",
+          "INTEL-SA-00837",
+          "INTEL-SA-00657",
+          "INTEL-SA-00767",
+          "INTEL-SA-00960",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 11,
+              "category": "BIOS",
+              "type": "Early Microcode Update"
+            },
+            {
+              "svn": 11,
+              "category": "OS/VMM",
+              "type": "SGX Late Microcode Update"
+            },
+            {
+              "svn": 3,
+              "category": "OS/VMM",
+              "type": "TXT SINIT"
+            },
+            {
+              "svn": 3,
+              "category": "BIOS"
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 13
+        },
+        "tcbDate": "2023-02-15T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded",
+        "advisoryIDs": [
+          "INTEL-SA-00828",
+          "INTEL-SA-00837",
+          "INTEL-SA-00657",
+          "INTEL-SA-00767",
+          "INTEL-SA-00960",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 7,
+              "category": "BIOS",
+              "type": "Early Microcode Update"
+            },
+            {
+              "svn": 9,
+              "category": "OS/VMM",
+              "type": "SGX Late Microcode Update"
+            },
+            {
+              "svn": 3,
+              "category": "OS/VMM",
+              "type": "TXT SINIT"
+            },
+            {
+              "svn": 3,
+              "category": "BIOS"
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 1
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 13
+        },
+        "tcbDate": "2022-08-10T00:00:00Z",
+        "tcbStatus": "OutOfDate",
+        "advisoryIDs": [
+          "INTEL-SA-00657",
+          "INTEL-SA-00730",
+          "INTEL-SA-00738",
+          "INTEL-SA-00767",
+          "INTEL-SA-00828",
+          "INTEL-SA-00837",
+          "INTEL-SA-00960",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 7,
+              "category": "BIOS",
+              "type": "Early Microcode Update"
+            },
+            {
+              "svn": 9,
+              "category": "OS/VMM",
+              "type": "SGX Late Microcode Update"
+            },
+            {
+              "svn": 3,
+              "category": "OS/VMM",
+              "type": "TXT SINIT"
+            },
+            {
+              "svn": 3,
+              "category": "BIOS"
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 13
+        },
+        "tcbDate": "2022-08-10T00:00:00Z",
+        "tcbStatus": "OutOfDateConfigurationNeeded",
+        "advisoryIDs": [
+          "INTEL-SA-00657",
+          "INTEL-SA-00730",
+          "INTEL-SA-00738",
+          "INTEL-SA-00767",
+          "INTEL-SA-00828",
+          "INTEL-SA-00837",
+          "INTEL-SA-00960",
+          "INTEL-SA-00615"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 4,
+              "category": "BIOS",
+              "type": "Early Microcode Update"
+            },
+            {
+              "svn": 4,
+              "category": "OS/VMM",
+              "type": "SGX Late Microcode Update"
+            },
+            {
+              "svn": 3,
+              "category": "OS/VMM",
+              "type": "TXT SINIT"
+            },
+            {
+              "svn": 3,
+              "category": "BIOS"
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 11
+        },
+        "tcbDate": "2021-11-10T00:00:00Z",
+        "tcbStatus": "OutOfDate",
+        "advisoryIDs": [
+          "INTEL-SA-00586",
+          "INTEL-SA-00614",
+          "INTEL-SA-00615",
+          "INTEL-SA-00657",
+          "INTEL-SA-00730",
+          "INTEL-SA-00738",
+          "INTEL-SA-00767",
+          "INTEL-SA-00828",
+          "INTEL-SA-00837",
+          "INTEL-SA-00960"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 4,
+              "category": "BIOS",
+              "type": "Early Microcode Update"
+            },
+            {
+              "svn": 4,
+              "category": "OS/VMM",
+              "type": "SGX Late Microcode Update"
+            },
+            {
+              "svn": 3,
+              "category": "OS/VMM",
+              "type": "TXT SINIT"
+            },
+            {
+              "svn": 3,
+              "category": "BIOS"
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 10
+        },
+        "tcbDate": "2020-11-11T00:00:00Z",
+        "tcbStatus": "OutOfDate",
+        "advisoryIDs": [
+          "INTEL-SA-00477",
+          "INTEL-SA-00586",
+          "INTEL-SA-00614",
+          "INTEL-SA-00615",
+          "INTEL-SA-00657",
+          "INTEL-SA-00730",
+          "INTEL-SA-00738",
+          "INTEL-SA-00767",
+          "INTEL-SA-00828",
+          "INTEL-SA-00837",
+          "INTEL-SA-00960"
+        ]
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 4,
+              "category": "BIOS",
+              "type": "Early Microcode Update"
+            },
+            {
+              "svn": 4,
+              "category": "OS/VMM",
+              "type": "SGX Late Microcode Update"
+            },
+            {
+              "svn": 3,
+              "category": "OS/VMM",
+              "type": "TXT SINIT"
+            },
+            {
+              "svn": 3,
+              "category": "BIOS"
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 255
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 5
+        },
+        "tcbDate": "2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate",
+        "advisoryIDs": [
+          "INTEL-SA-00106",
+          "INTEL-SA-00115",
+          "INTEL-SA-00135",
+          "INTEL-SA-00203",
+          "INTEL-SA-00220",
+          "INTEL-SA-00233",
+          "INTEL-SA-00270",
+          "INTEL-SA-00293",
+          "INTEL-SA-00320",
+          "INTEL-SA-00329",
+          "INTEL-SA-00381",
+          "INTEL-SA-00389",
+          "INTEL-SA-00477",
+          "INTEL-SA-00586",
+          "INTEL-SA-00614",
+          "INTEL-SA-00615",
+          "INTEL-SA-00657",
+          "INTEL-SA-00730",
+          "INTEL-SA-00738",
+          "INTEL-SA-00767",
+          "INTEL-SA-00828",
+          "INTEL-SA-00837",
+          "INTEL-SA-00960"
+        ]
+      }
+    ]
+  },
+  "signature": "e51a6179b2d40660aef2daa0c411d433816ff3b56e66e46df95cda51c1da490ee2cd48c6d04031af6143103f8a7c7cfd57ae0ec43329da50aec271798650a794"
+}

--- a/packages/qvl/test/sample/sgx/tcbInfo-90c06f000000.json
+++ b/packages/qvl/test/sample/sgx/tcbInfo-90c06f000000.json
@@ -1,0 +1,167 @@
+{
+  "tcbInfo": {
+    "id": "SGX",
+    "version": 3,
+    "issueDate": "2025-09-28T05:52:20Z",
+    "nextUpdate": "2025-10-28T05:52:20Z",
+    "fmspc": "90c06f000000",
+    "pceId": "0000",
+    "tcbType": 0,
+    "tcbEvaluationDataNumber": 17,
+    "tcbLevels": [
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 2,
+              "category": "BIOS",
+              "type": "Early Microcode Update"
+            },
+            {
+              "svn": 2,
+              "category": "OS/VMM",
+              "type": "SGX Late Microcode Update"
+            },
+            {
+              "svn": 2,
+              "category": "OS/VMM",
+              "type": "TXT SINIT"
+            },
+            {
+              "svn": 2,
+              "category": "BIOS"
+            },
+            {
+              "svn": 3,
+              "category": "BIOS"
+            },
+            {
+              "svn": 1,
+              "category": "BIOS"
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 3,
+              "category": "OS/VMM",
+              "type": "SEAMLDR ACM"
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 13
+        },
+        "tcbDate": "2024-03-13T00:00:00Z",
+        "tcbStatus": "UpToDate"
+      },
+      {
+        "tcb": {
+          "sgxtcbcomponents": [
+            {
+              "svn": 2,
+              "category": "BIOS",
+              "type": "Early Microcode Update"
+            },
+            {
+              "svn": 2,
+              "category": "OS/VMM",
+              "type": "SGX Late Microcode Update"
+            },
+            {
+              "svn": 2,
+              "category": "OS/VMM",
+              "type": "TXT SINIT"
+            },
+            {
+              "svn": 2,
+              "category": "BIOS"
+            },
+            {
+              "svn": 3,
+              "category": "BIOS"
+            },
+            {
+              "svn": 1,
+              "category": "BIOS"
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 3,
+              "category": "OS/VMM",
+              "type": "SEAMLDR ACM"
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            },
+            {
+              "svn": 0
+            }
+          ],
+          "pcesvn": 5
+        },
+        "tcbDate": "2018-01-04T00:00:00Z",
+        "tcbStatus": "OutOfDate",
+        "advisoryIDs": [
+          "INTEL-SA-00106",
+          "INTEL-SA-00115",
+          "INTEL-SA-00135",
+          "INTEL-SA-00203",
+          "INTEL-SA-00220",
+          "INTEL-SA-00233",
+          "INTEL-SA-00270",
+          "INTEL-SA-00293",
+          "INTEL-SA-00320",
+          "INTEL-SA-00329",
+          "INTEL-SA-00381",
+          "INTEL-SA-00389",
+          "INTEL-SA-00477",
+          "INTEL-SA-00837"
+        ]
+      }
+    ]
+  },
+  "signature": "b2c3ada7794e0a2828cbee556ec379e887d6c9791302b75880a131f559f574ab858486388d7c87283a72654613df7e27857814fce8f9da3b15f79159863fc668"
+}


### PR DESCRIPTION
Add `qvl-tcb.test.ts` to verify SGX quote TCB freshness and status using the `verifyFmspc` interface and cached Intel TCB info.

The test fetches and caches TCB information from Intel's API for each FMSPC found in sample quotes. It then uses a custom `verifyFmspc` callback to evaluate the TCB status (UpToDate, ConfigurationNeeded, OutOfDateConfigurationNeeded) and freshness against a `BASE_TIME`. The test asserts that `verifySgx` either passes for acceptable TCB states or fails with a "TCB validation failed" message for unacceptable/stale states, including cases where Intel API calls return 404.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f5aa7bc-49bb-41fe-9e6b-737f653ae622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6f5aa7bc-49bb-41fe-9e6b-737f653ae622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

