### PR TITLE
Assert pcesvn in valid quote tests

### DIFF
--- a/packages/qvl/test/qvl-sgx.test.ts
+++ b/packages/qvl/test/qvl-sgx.test.ts
@@ -64,6 +64,7 @@ test.serial("Verify an SGX quote from Intel, no quote signature", async (t) => {
     extraCertdata: certdata,
   })
   t.is(fmspc, "00707f000000")
+  t.is(header.pce_svn, 3)
 
   t.true(
     await verifySgx(quote, {
@@ -91,6 +92,7 @@ test.serial("Verify an SGX quote from Occlum", async (t) => {
   t.is(hex(body.mr_enclave), expectedMrEnclave)
   t.is(hex(body.report_data), expectedReportData)
   t.is(fmspc, "30606a000000")
+  t.is(header.pce_svn, 13)
 
   t.true(
     await verifySgx(quote, {
@@ -116,6 +118,7 @@ test.serial("Verify an SGX quote from chinenyeokafor", async (t) => {
   t.is(hex(body.mr_enclave), expectedMrEnclave)
   t.is(hex(body.report_data), expectedReportData)
   t.is(fmspc, "90c06f000000")
+  t.is(header.pce_svn, 16)
 
   t.true(
     await verifySgx(quote, {
@@ -141,6 +144,7 @@ test.serial("Verify an SGX quote from TLSN, quote9", async (t) => {
   t.is(hex(body.mr_enclave), expectedMrEnclave)
   t.is(hex(body.report_data), expectedReportData)
   t.is(fmspc, "00906ed50000")
+  t.is(header.pce_svn, 16)
 
   t.true(
     await verifySgx(quote, {
@@ -166,6 +170,7 @@ test.serial("Verify an SGX quote from TLSN, quote_dev", async (t) => {
   t.is(hex(body.mr_enclave), expectedMrEnclave)
   t.is(hex(body.report_data), expectedReportData)
   t.is(fmspc, "00906ed50000")
+  t.is(header.pce_svn, 16)
 
   t.true(
     await verifySgx(quote, {

--- a/packages/qvl/test/qvl-tcb.test.ts
+++ b/packages/qvl/test/qvl-tcb.test.ts
@@ -9,6 +9,8 @@ import {
   IntelTcbInfo,
   VerifyConfig,
   isTdxQuote,
+  parseTdxQuote,
+  parseSgxQuote,
 } from "ra-https-qvl"
 
 const BASE_TIME = Date.parse("2025-09-29T23:00:00Z")
@@ -147,9 +149,10 @@ async function assertTcb(
     status: string
     fresh: boolean
     fmspc: string
+    pceSvn: number
   },
 ) {
-  const { _tdx, _b64, _json, valid, status, fresh, fmspc } = config
+  const { _tdx, _b64, _json, valid, status, fresh, fmspc, pceSvn } = config
 
   const quote: Uint8Array = _b64
     ? scureBase64.decode(fs.readFileSync(path, "utf-8"))
@@ -168,6 +171,10 @@ async function assertTcb(
   t.is(stateRef.fmspc, fmspc)
   t.is(stateRef.status, status)
   t.is(stateRef.freshnessOk, fresh)
+  
+  // Also verify PCESVN from quote header
+  const parsedQuote = _tdx ? parseTdxQuote(quote) : parseSgxQuote(quote)
+  t.is(parsedQuote.header.pce_svn, pceSvn)
 }
 
 test.serial("Evaluate TCB (SGX): occlum", async (t) => {
@@ -177,6 +184,7 @@ test.serial("Evaluate TCB (SGX): occlum", async (t) => {
     status: "OutOfDate",
     fresh: true,
     fmspc: "30606a000000",
+    pceSvn: 13,
   })
 })
 
@@ -187,6 +195,7 @@ test.serial("Evaluate TCB (SGX): chinenyeokafor", async (t) => {
     status: "UpToDate",
     fresh: true,
     fmspc: "90c06f000000",
+    pceSvn: 16,
   })
 })
 
@@ -197,6 +206,7 @@ test.serial("Evaluate TCB (SGX): tlsn-quote9", async (t) => {
     status: "SWHardeningNeeded",
     fresh: true,
     fmspc: "00906ed50000",
+    pceSvn: 16,
   })
 })
 
@@ -207,6 +217,7 @@ test.serial("Evaluate TCB (SGX): tlsn-quotedev", async (t) => {
     status: "SWHardeningNeeded",
     fresh: true,
     fmspc: "00906ed50000",
+    pceSvn: 16,
   })
 })
 
@@ -217,6 +228,7 @@ test.serial("Evaluate TCB (TDX v5): trustee", async (t) => {
     status: "OutOfDate",
     fresh: true,
     fmspc: "90c06f000000",
+    pceSvn: 0,
   })
 })
 
@@ -228,6 +240,7 @@ test.serial("Evaluate TCB (TDX v4): azure", async (t) => {
     status: "OutOfDate",
     fresh: true,
     fmspc: "00806f050000",
+    pceSvn: 0,
   })
 })
 
@@ -238,6 +251,7 @@ test.serial("Evaluate TCB (TDX v4): edgeless", async (t) => {
     status: "OutOfDate",
     fresh: true,
     fmspc: "00806f050000",
+    pceSvn: 0,
   })
 })
 
@@ -249,6 +263,7 @@ test.serial("Evaluate TCB (TDX v4): gcp", async (t) => {
     status: "OutOfDate",
     fresh: true,
     fmspc: "00806f050000",
+    pceSvn: 0,
   })
 })
 
@@ -260,6 +275,7 @@ test.serial("Evaluate TCB (TDX v4): gcp no nonce", async (t) => {
     status: "OutOfDate",
     fresh: true,
     fmspc: "00806f050000",
+    pceSvn: 0,
   })
 })
 
@@ -270,6 +286,7 @@ test.serial("Evaluate TCB (TDX v4): moemahhouk", async (t) => {
     status: "OutOfDate",
     fresh: true,
     fmspc: "90c06f000000",
+    pceSvn: 13,
   })
 })
 
@@ -280,6 +297,7 @@ test.serial("Evaluate TCB (TDX v4): phala", async (t) => {
     status: "OutOfDate",
     fresh: true,
     fmspc: "b0c06f000000",
+    pceSvn: 0,
   })
 })
 
@@ -290,6 +308,7 @@ test.serial("Evaluate TCB (TDX v4): trustee", async (t) => {
     status: "OutOfDate",
     fresh: true,
     fmspc: "50806f000000",
+    pceSvn: 0,
   })
 })
 
@@ -300,5 +319,6 @@ test.serial("Evaluate TCB (TDX v4): zkdcap", async (t) => {
     status: "OutOfDate",
     fresh: true,
     fmspc: "00806f050000",
+    pceSvn: 0,
   })
 })

--- a/packages/qvl/test/qvl-tdxv5.test.ts
+++ b/packages/qvl/test/qvl-tdxv5.test.ts
@@ -36,6 +36,7 @@ test.serial("Verify a V5 TDX quote from Trustee", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.is(fmspc, "90c06f000000")
+  t.is(header.pce_svn, 0)
 
   t.true(
     await verifyTdx(quote, {

--- a/packages/qvl/test/qvl.test.ts
+++ b/packages/qvl/test/qvl.test.ts
@@ -46,6 +46,7 @@ test.serial("Verify a V4 TDX quote from Tappd", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.is(fmspc, "b0c06f000000")
+  t.is(header.pce_svn, 0)
 
   t.true(
     await verifyTdx(quote, {
@@ -75,6 +76,7 @@ test.serial("Verify a V4 TDX quote from Edgeless", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.is(fmspc, "00806f050000")
+  t.is(header.pce_svn, 0)
 
   t.true(
     await verifyTdx(quote, {
@@ -104,6 +106,7 @@ test.serial("Verify a V4 TDX quote from Phala, bin format", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.is(fmspc, "b0c06f000000")
+  t.is(header.pce_svn, 0)
 
   t.true(
     await verifyTdx(quote, {
@@ -134,6 +137,7 @@ test.serial("Verify a V4 TDX quote from Phala, hex format", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.is(fmspc, "b0c06f000000")
+  t.is(header.pce_svn, 0)
 
   t.true(
     await verifyTdx(quote, {
@@ -165,6 +169,7 @@ test.serial("Verify a V4 TDX quote from MoeMahhouk", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.is(fmspc, "90c06f000000")
+  t.is(header.pce_svn, 0)
 
   t.true(
     await verifyTdx(quote, {
@@ -193,6 +198,7 @@ test.serial("Verify a V4 TDX quote from Azure", async (t) => {
   t.deepEqual(body.mr_owner, new Uint8Array(48))
   t.deepEqual(body.mr_owner_config, new Uint8Array(48))
   t.is(fmspc, "00806f050000")
+  t.is(header.pce_svn, 0)
 
   t.true(
     await verifyTdxBase64(quote, {
@@ -221,6 +227,7 @@ test.serial("Verify a V4 TDX quote from Trustee", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.is(fmspc, "50806f000000")
+  t.is(header.pce_svn, 0)
 
   t.true(
     await verifyTdx(quote, {
@@ -249,6 +256,7 @@ test.serial("Verify a V4 TDX quote from ZKDCAP", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.is(fmspc, "00806f050000")
+  t.is(header.pce_svn, 0)
 
   t.true(
     await verifyTdx(quote, {
@@ -300,6 +308,7 @@ test.serial("Verify a V4 TDX quote from Intel", async (t) => {
     verifyTcb: () => true,
   })
   t.is(fmspc, "ed742af8adf5")
+  t.is(header.pce_svn, 0)
 
   t.true(
     await verifyTdx(quote, {
@@ -333,6 +342,7 @@ test.serial("Verify a V4 TDX quote from GCP", async (t) => {
   t.deepEqual(body.mr_owner, new Uint8Array(48))
   t.deepEqual(body.mr_owner_config, new Uint8Array(48))
   t.is(fmspc, "00806f050000")
+  t.is(header.pce_svn, 0)
 
   t.true(
     await verifyTdxBase64(quote, {


### PR DESCRIPTION
Add PCESVN assertions to all positive quote verification tests in the `packages/qvl` module to confirm expected PCE versioning.

---
<a href="https://cursor.com/background-agent?bcId=bc-42fb460d-04fc-432e-a8f5-519d2cf648b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-42fb460d-04fc-432e-a8f5-519d2cf648b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

