### PR TITLE
Extract PCESVN from PCK certificate extension

### DIFF
--- a/packages/qvl/src/verifySgx.ts
+++ b/packages/qvl/src/verifySgx.ts
@@ -177,7 +177,7 @@ export async function _verifySgx(quote: Uint8Array, config?: VerifyConfig) {
   const parsedQuote = parseSgxQuote(quote)
   const { signature, header } = parsedQuote
   const certs = extractPemCertificates(signature.cert_data)
-  let { status, root, fmspc } = await verifyPCKChain(
+  let { status, root, fmspc, pcesvn } = await verifyPCKChain(
     certs,
     date ?? +new Date(),
     crls,
@@ -196,12 +196,14 @@ export async function _verifySgx(quote: Uint8Array, config?: VerifyConfig) {
     status = fallback.status
     root = fallback.root
     fmspc = fallback.fmspc
+    pcesvn = fallback.pcesvn
   }
 
   return {
     status,
     root,
     fmspc,
+    pcesvn,
     signature,
     header,
     extraCertdata,

--- a/packages/qvl/src/verifyTdx.ts
+++ b/packages/qvl/src/verifyTdx.ts
@@ -47,9 +47,10 @@ export async function verifyPCKChain(
   root: QV_X509Certificate | null
   chain: QV_X509Certificate[]
   fmspc: string | null
+  pcesvn: number | null
 }> {
   if (certData.length === 0) {
-    return { status: "invalid", root: null, chain: [], fmspc: null }
+    return { status: "invalid", root: null, chain: [], fmspc: null, pcesvn: null }
   }
 
   // Build certificate objects using @peculiar/x509
@@ -80,7 +81,7 @@ export async function verifyPCKChain(
     const child = chain[i]
     const parent = chain[i + 1]
     if (child.issuer !== parent.subject)
-      return { status: "invalid", root: null, chain: [], fmspc: null }
+      return { status: "invalid", root: null, chain: [], fmspc: null, pcesvn: null }
   }
 
   // Check for expired or not-yet-valid certificates
@@ -93,7 +94,8 @@ export async function verifyPCKChain(
     ) {
       const root = chain[chain.length - 1] ?? null
       const fmspc = leaf.getFmspcHex()
-      return { status: "expired", root, chain, fmspc }
+      const pcesvn = leaf.getPceSvn()
+      return { status: "expired", root, chain, fmspc, pcesvn }
     }
   }
 
@@ -102,7 +104,7 @@ export async function verifyPCKChain(
   if (terminal && terminal.subject === terminal.issuer) {
     const valid = await terminal.verify(terminal)
     if (!valid) {
-      return { status: "invalid", root: null, chain: [], fmspc: null }
+      return { status: "invalid", root: null, chain: [], fmspc: null, pcesvn: null }
     }
   }
 
@@ -112,7 +114,7 @@ export async function verifyPCKChain(
     const parent = chain[i + 1]
     const valid = await child.verify(parent)
     if (!valid) {
-      return { status: "invalid", root: null, chain: [], fmspc: null }
+      return { status: "invalid", root: null, chain: [], fmspc: null, pcesvn: null }
     }
   }
 
@@ -131,7 +133,7 @@ export async function verifyPCKChain(
   const leafNode = chain[0]
   const bc = leafNode.getExtension(BasicConstraintsExtension)
   if (bc && bc.ca) {
-    return { status: "invalid", root: null, chain: [], fmspc: null }
+    return { status: "invalid", root: null, chain: [], fmspc: null, pcesvn: null }
   }
 
   // CA and pathLen checks for all issuers in the chain
@@ -140,7 +142,7 @@ export async function verifyPCKChain(
     const bc = issuerNode.getExtension(BasicConstraintsExtension)
 
     if (!bc || !bc.ca) {
-      return { status: "invalid", root: null, chain: [], fmspc: null }
+      return { status: "invalid", root: null, chain: [], fmspc: null, pcesvn: null }
     }
 
     // pathLenConstraint validation: number of subsequent non-self-issued CA certs
@@ -150,12 +152,13 @@ export async function verifyPCKChain(
         if (isCAInChain[j]) subsequentCAs++
       }
       if (subsequentCAs > bc.pathLength) {
-        return { status: "invalid", root: null, chain: [], fmspc: null }
+        return { status: "invalid", root: null, chain: [], fmspc: null, pcesvn: null }
       }
     }
   }
 
   const fmspc = leaf.getFmspcHex()
+  const pcesvn = leaf.getPceSvn()
 
   // CRL: Check all certificates in the PCK chain against revocation lists
   if (crls && crls.length > 0) {
@@ -169,14 +172,14 @@ export async function verifyPCKChain(
         // Node returns colonless/colon-separated uppercase hex; normalize
         const serial = normalizeSerialHex(cert.serialNumber)
         if (revoked.has(serial)) {
-          return { status: "revoked", root: null, chain: [], fmspc }
+          return { status: "revoked", root: null, chain: [], fmspc, pcesvn }
         }
       }
     }
   }
 
   const root = chain[chain.length - 1] ?? null
-  return { status: "valid", root, chain, fmspc }
+  return { status: "valid", root, chain, fmspc, pcesvn }
 }
 
 /**
@@ -364,7 +367,7 @@ export async function _verifyTdx(quote: Uint8Array, config?: VerifyConfig) {
   const parsedQuote = parseTdxQuote(quote)
   const { signature, header } = parsedQuote
   const certs = extractPemCertificates(signature.cert_data)
-  let { status, root, fmspc } = await verifyPCKChain(
+  let { status, root, fmspc, pcesvn } = await verifyPCKChain(
     certs,
     date ?? +new Date(),
     crls,
@@ -383,12 +386,14 @@ export async function _verifyTdx(quote: Uint8Array, config?: VerifyConfig) {
     status = fallback.status
     root = fallback.root
     fmspc = fallback.fmspc
+    pcesvn = fallback.pcesvn
   }
 
   return {
     status,
     root,
     fmspc,
+    pcesvn,
     signature,
     header,
     extraCertdata,

--- a/packages/qvl/test/qvl-sgx.test.ts
+++ b/packages/qvl/test/qvl-sgx.test.ts
@@ -58,12 +58,13 @@ test.serial("Verify an SGX quote from Intel, no quote signature", async (t) => {
     fs.readFileSync("test/sample/sgx/intermediateCaCrl.der"),
   ]
 
-  const { fmspc } = await _verifySgx(quote, {
+  const { fmspc, pcesvn } = await _verifySgx(quote, {
     crls: [],
     verifyTcb: () => true,
     extraCertdata: certdata,
   })
   t.is(fmspc, "00707f000000")
+  t.log("PCESVN:", pcesvn)
 
   t.true(
     await verifySgx(quote, {
@@ -79,7 +80,7 @@ test.serial("Verify an SGX quote from Intel, no quote signature", async (t) => {
 test.serial("Verify an SGX quote from Occlum", async (t) => {
   const quote = fs.readFileSync("test/sample/sgx-occlum.dat")
   const { header, body } = parseSgxQuote(quote)
-  const { fmspc } = await _verifySgx(quote)
+  const { fmspc, pcesvn } = await _verifySgx(quote)
 
   const expectedMrEnclave =
     "9c90fd81f6e9fe64b46b14f0623523a52d6a5678482988c408f6adffe6301e2c"
@@ -91,6 +92,7 @@ test.serial("Verify an SGX quote from Occlum", async (t) => {
   t.is(hex(body.mr_enclave), expectedMrEnclave)
   t.is(hex(body.report_data), expectedReportData)
   t.is(fmspc, "30606a000000")
+  t.log("PCESVN:", pcesvn)
 
   t.true(
     await verifySgx(quote, {
@@ -104,7 +106,7 @@ test.serial("Verify an SGX quote from Occlum", async (t) => {
 test.serial("Verify an SGX quote from chinenyeokafor", async (t) => {
   const quote = fs.readFileSync("test/sample/sgx-chinenyeokafor.dat")
   const { header, body } = parseSgxQuote(quote)
-  const { fmspc } = await _verifySgx(quote)
+  const { fmspc, pcesvn } = await _verifySgx(quote)
 
   const expectedMrEnclave =
     "0696ab235b2d339e68a4303cb64cde005bb8cdf2448bed742ac8ea8339bd0cb7"
@@ -116,6 +118,7 @@ test.serial("Verify an SGX quote from chinenyeokafor", async (t) => {
   t.is(hex(body.mr_enclave), expectedMrEnclave)
   t.is(hex(body.report_data), expectedReportData)
   t.is(fmspc, "90c06f000000")
+  t.log("PCESVN:", pcesvn)
 
   t.true(
     await verifySgx(quote, {
@@ -129,7 +132,7 @@ test.serial("Verify an SGX quote from chinenyeokafor", async (t) => {
 test.serial("Verify an SGX quote from TLSN, quote9", async (t) => {
   const quote = fs.readFileSync("test/sample/sgx-tlsn-quote9.dat")
   const { header, body } = parseSgxQuote(quote)
-  const { fmspc } = await _verifySgx(quote)
+  const { fmspc, pcesvn } = await _verifySgx(quote)
 
   const expectedMrEnclave =
     "50a6a608c1972408f94379f83a7af2ea55b31095f131efe93af74f5968a44f29"
@@ -141,6 +144,7 @@ test.serial("Verify an SGX quote from TLSN, quote9", async (t) => {
   t.is(hex(body.mr_enclave), expectedMrEnclave)
   t.is(hex(body.report_data), expectedReportData)
   t.is(fmspc, "00906ed50000")
+  t.log("PCESVN:", pcesvn)
 
   t.true(
     await verifySgx(quote, {
@@ -154,7 +158,7 @@ test.serial("Verify an SGX quote from TLSN, quote9", async (t) => {
 test.serial("Verify an SGX quote from TLSN, quote_dev", async (t) => {
   const quote = fs.readFileSync("test/sample/sgx-tlsn-quotedev.dat")
   const { header, body } = parseSgxQuote(quote)
-  const { fmspc } = await _verifySgx(quote)
+  const { fmspc, pcesvn } = await _verifySgx(quote)
 
   const expectedMrEnclave =
     "db5e55d3190d92512e4eae09d697b4b5fe30c2212e1ad6db5681379608c46204"
@@ -166,6 +170,7 @@ test.serial("Verify an SGX quote from TLSN, quote_dev", async (t) => {
   t.is(hex(body.mr_enclave), expectedMrEnclave)
   t.is(hex(body.report_data), expectedReportData)
   t.is(fmspc, "00906ed50000")
+  t.log("PCESVN:", pcesvn)
 
   t.true(
     await verifySgx(quote, {

--- a/packages/qvl/test/qvl-tdxv5.test.ts
+++ b/packages/qvl/test/qvl-tdxv5.test.ts
@@ -21,7 +21,7 @@ const BASE_TIME = Date.parse("2025-09-01")
 test.serial("Verify a V5 TDX quote from Trustee", async (t) => {
   const quote = fs.readFileSync("test/sample/tdx-v5-trustee.dat")
   const { header, body } = parseTdxQuote(quote)
-  const { fmspc } = await _verifyTdx(quote)
+  const { fmspc, pcesvn } = await _verifyTdx(quote)
 
   const expectedMRTD =
     "dfba221b48a22af8511542ee796603f37382800840dcd978703909bf8e64d4c8a1e9de86e7c9638bfcba422f3886400a"
@@ -36,6 +36,7 @@ test.serial("Verify a V5 TDX quote from Trustee", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.is(fmspc, "90c06f000000")
+  t.log("PCESVN:", pcesvn)
 
   t.true(
     await verifyTdx(quote, {

--- a/packages/qvl/test/qvl.test.ts
+++ b/packages/qvl/test/qvl.test.ts
@@ -31,7 +31,7 @@ test.serial("Verify a V4 TDX quote from Tappd", async (t) => {
   const quote = Buffer.from(quoteHex.replace(/^0x/, ""), "hex")
 
   const { header, body } = parseTdxQuote(quote)
-  const { fmspc } = await _verifyTdx(quote)
+  const { fmspc, pcesvn } = await _verifyTdx(quote)
 
   const expectedMRTD =
     "c68518a0ebb42136c12b2275164f8c72f25fa9a34392228687ed6e9caeb9c0f1dbd895e9cf475121c029dc47e70e91fd"
@@ -46,6 +46,7 @@ test.serial("Verify a V4 TDX quote from Tappd", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.is(fmspc, "b0c06f000000")
+  t.log("PCESVN:", pcesvn)
 
   t.true(
     await verifyTdx(quote, {
@@ -60,7 +61,7 @@ test.serial("Verify a V4 TDX quote from Edgeless", async (t) => {
   const quote = fs.readFileSync("test/sample/tdx-v4-edgeless.dat")
 
   const { header, body } = parseTdxQuote(quote)
-  const { fmspc } = await _verifyTdx(quote)
+  const { fmspc, pcesvn } = await _verifyTdx(quote)
 
   const expectedMRTD =
     "b65ea009e424e6f761fdd3d7c8962439453b37ecdf62da04f7bc5d327686bb8bafc8a5d24a9c31cee60e4aba87c2f71b"
@@ -75,6 +76,7 @@ test.serial("Verify a V4 TDX quote from Edgeless", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.is(fmspc, "00806f050000")
+  t.log("PCESVN:", pcesvn)
 
   t.true(
     await verifyTdx(quote, {
@@ -89,7 +91,7 @@ test.serial("Verify a V4 TDX quote from Phala, bin format", async (t) => {
   const quote = fs.readFileSync("test/sample/tdx-v4-phala.dat")
 
   const { header, body } = parseTdxQuote(quote)
-  const { fmspc } = await _verifyTdx(quote)
+  const { fmspc, pcesvn } = await _verifyTdx(quote)
 
   const expectedMRTD =
     "91eb2b44d141d4ece09f0c75c2c53d247a3c68edd7fafe8a3520c942a604a407de03ae6dc5f87f27428b2538873118b7"
@@ -104,6 +106,7 @@ test.serial("Verify a V4 TDX quote from Phala, bin format", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.is(fmspc, "b0c06f000000")
+  t.log("PCESVN:", pcesvn)
 
   t.true(
     await verifyTdx(quote, {
@@ -119,7 +122,7 @@ test.serial("Verify a V4 TDX quote from Phala, hex format", async (t) => {
   const quote = Buffer.from(quoteHex.replace(/^0x/, ""), "hex")
 
   const { header, body } = parseTdxQuote(quote)
-  const { fmspc } = await _verifyTdx(quote)
+  const { fmspc, pcesvn } = await _verifyTdx(quote)
 
   const expectedMRTD =
     "7ba9e262ce6979087e34632603f354dd8f8a870f5947d116af8114db6c9d0d74c48bec4280e5b4f4a37025a10905bb29"
@@ -134,6 +137,7 @@ test.serial("Verify a V4 TDX quote from Phala, hex format", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.is(fmspc, "b0c06f000000")
+  t.log("PCESVN:", pcesvn)
 
   t.true(
     await verifyTdx(quote, {
@@ -148,7 +152,7 @@ test.serial("Verify a V4 TDX quote from MoeMahhouk", async (t) => {
   const quote = fs.readFileSync("test/sample/tdx-v4-moemahhouk.dat")
 
   const { header, body } = parseTdxQuote(quote)
-  const { fmspc } = await _verifyTdx(quote)
+  const { fmspc, pcesvn } = await _verifyTdx(quote)
 
   const expectedMRTD = reverseHexBytes(
     "18bcec2014a3ff000c46191e960ca4fe949f9adb2d8da557dbacee87f6ef7e2411fd5f09dc2b834506959bf69626ddf2",
@@ -165,6 +169,7 @@ test.serial("Verify a V4 TDX quote from MoeMahhouk", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.is(fmspc, "90c06f000000")
+  t.log("PCESVN:", pcesvn)
 
   t.true(
     await verifyTdx(quote, {
@@ -178,7 +183,7 @@ test.serial("Verify a V4 TDX quote from MoeMahhouk", async (t) => {
 test.serial("Verify a V4 TDX quote from Azure", async (t) => {
   const quote = fs.readFileSync("test/sample/tdx-v4-azure", "utf-8")
   const { header, body } = parseTdxQuoteBase64(quote)
-  const { fmspc } = await _verifyTdx(scureBase64.decode(quote))
+  const { fmspc, pcesvn } = await _verifyTdx(scureBase64.decode(quote))
 
   const expectedMRTD =
     "fe27b2aa3a05ec56864c308aff03dd13c189a6112d21e417ec1afe626a8cb9d91482d1379ec02fe6308972950a930d0a"
@@ -193,6 +198,7 @@ test.serial("Verify a V4 TDX quote from Azure", async (t) => {
   t.deepEqual(body.mr_owner, new Uint8Array(48))
   t.deepEqual(body.mr_owner_config, new Uint8Array(48))
   t.is(fmspc, "00806f050000")
+  t.log("PCESVN:", pcesvn)
 
   t.true(
     await verifyTdxBase64(quote, {
@@ -206,7 +212,7 @@ test.serial("Verify a V4 TDX quote from Azure", async (t) => {
 test.serial("Verify a V4 TDX quote from Trustee", async (t) => {
   const quote = fs.readFileSync("test/sample/tdx-v4-trustee.dat")
   const { header, body } = parseTdxQuote(quote)
-  const { fmspc } = await _verifyTdx(quote)
+  const { fmspc, pcesvn } = await _verifyTdx(quote)
 
   const expectedMRTD =
     "705ee9381b8633a9fbe532b52345e8433343d2868959f57889d84ca377c395b689cac1599ccea1b7d420483a9ce5f031"
@@ -221,6 +227,7 @@ test.serial("Verify a V4 TDX quote from Trustee", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.is(fmspc, "50806f000000")
+  t.log("PCESVN:", pcesvn)
 
   t.true(
     await verifyTdx(quote, {
@@ -234,7 +241,7 @@ test.serial("Verify a V4 TDX quote from Trustee", async (t) => {
 test.serial("Verify a V4 TDX quote from ZKDCAP", async (t) => {
   const quote = fs.readFileSync("test/sample/tdx-v4-zkdcap.dat")
   const { header, body } = parseTdxQuote(quote)
-  const { fmspc } = await _verifyTdx(quote)
+  const { fmspc, pcesvn } = await _verifyTdx(quote)
 
   const expectedMRTD =
     "935be7742dd89c6a4df6dba8353d89041ae0f052beef993b1e7f4524d3bc57650df20e5582158352e1240b3f1fed55d8"
@@ -249,6 +256,7 @@ test.serial("Verify a V4 TDX quote from ZKDCAP", async (t) => {
   t.deepEqual(body.mr_owner, Buffer.alloc(48))
   t.deepEqual(body.mr_owner_config, Buffer.alloc(48))
   t.is(fmspc, "00806f050000")
+  t.log("PCESVN:", pcesvn)
 
   t.true(
     await verifyTdx(quote, {
@@ -294,12 +302,13 @@ test.serial("Verify a V4 TDX quote from Intel", async (t) => {
     fs.readFileSync("test/sample/tdx/intermediateCaCrl.der"),
   ]
 
-  const { fmspc } = await _verifyTdx(quote, {
+  const { fmspc, pcesvn } = await _verifyTdx(quote, {
     extraCertdata: certdata,
     crls,
     verifyTcb: () => true,
   })
   t.is(fmspc, "ed742af8adf5")
+  t.log("PCESVN:", pcesvn)
 
   t.true(
     await verifyTdx(quote, {
@@ -318,7 +327,7 @@ test.serial("Verify a V4 TDX quote from GCP", async (t) => {
   )
   const quote: string = data.tdx.quote
   const { header, body } = parseTdxQuoteBase64(quote)
-  const { fmspc } = await _verifyTdx(scureBase64.decode(quote))
+  const { fmspc, pcesvn } = await _verifyTdx(scureBase64.decode(quote))
 
   const expectedMRTD =
     "409c0cd3e63d9ea54d817cf851983a220131262664ac8cd02cc6a2e19fd291d2fdd0cc035d7789b982a43a92a4424c99"
@@ -333,6 +342,7 @@ test.serial("Verify a V4 TDX quote from GCP", async (t) => {
   t.deepEqual(body.mr_owner, new Uint8Array(48))
   t.deepEqual(body.mr_owner_config, new Uint8Array(48))
   t.is(fmspc, "00806f050000")
+  t.log("PCESVN:", pcesvn)
 
   t.true(
     await verifyTdxBase64(quote, {


### PR DESCRIPTION
Extract PCESVN from PCK certificates and log it in verification tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-e516408a-b3bc-4ae4-8862-242b28d9b166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e516408a-b3bc-4ae4-8862-242b28d9b166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

